### PR TITLE
Fix empty string cells producing invalid sharedStrings index -1

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -967,8 +967,18 @@ begin
                 end;
               TCellType.StringValue:
                 begin
-                  const StrIdx = GetSharedStringIndex(SharedStrings, Cell.GetAsString);
-                  SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + ' t="s"><v>' + IntToStr(StrIdx) + '</v></c>');
+                  // Empty strings are excluded from sharedStrings (see BuildSharedStrings), so a
+                  // lookup would yield the invalid index -1. Write them as value-less cells instead.
+                  if Cell.GetAsString = '' then
+                  begin
+                    if StyleIdx > 0 then
+                      SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + '/>');
+                  end
+                  else
+                  begin
+                    const StrIdx = GetSharedStringIndex(SharedStrings, Cell.GetAsString);
+                    SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + ' t="s"><v>' + IntToStr(StrIdx) + '</v></c>');
+                  end;
                 end;
               TCellType.Boolean:
                 begin

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -164,6 +164,12 @@ type
 
     [Test]
     procedure RoundTrip_CombinedFormatting_PreservesAll;
+
+    [Test]
+    procedure SaveToFile_EmptyStringCell_WritesNoInvalidSharedStringIndex;
+
+    [Test]
+    procedure RoundTrip_EmptyStringCell_PreservesAdjacentValues;
   end;
 
 implementation
@@ -1002,6 +1008,45 @@ begin
   Assert.AreEqual(Ord(TExcelVAlign.Bottom), Ord(Cell.VAlign));
   Assert.IsTrue(Cell.WrapText, 'Should have wrapText');
   Assert.AreEqual(Double(30), Workbook2.Sheets[0].GetRowHeight(1), 0.01);
+end;
+
+procedure TExcelWriteTests.SaveToFile_EmptyStringCell_WritesNoInvalidSharedStringIndex;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Filled';
+  Sheet.Cell['B1'].AsString := '';
+  Sheet.Cell['C1'].AsString := '';
+  Sheet.Cell['C1'].Bold := True;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsFalse(Pos('<v>-1</v>', SheetXml) > 0, 'Empty string cells should not reference sharedStrings index -1');
+    Assert.IsFalse(Pos('r="B1"', SheetXml) > 0, 'Unstyled empty string cell should be omitted');
+    Assert.IsTrue(Pos('r="C1"', SheetXml) > 0, 'Styled empty string cell should be written');
+    Assert.IsFalse(Pos('r="C1" s="1" t="s"', SheetXml) > 0, 'Styled empty string cell should not be a shared string cell');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.RoundTrip_EmptyStringCell_PreservesAdjacentValues;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Left';
+  Sheet.Cell['B1'].AsString := '';
+  Sheet.Cell['C1'].AsString := 'Right';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual('Left', Workbook2.Sheets[0].Cell['A1'].AsString);
+  Assert.AreEqual('', Workbook2.Sheets[0].Cell['B1'].AsString);
+  Assert.AreEqual('Right', Workbook2.Sheets[0].Cell['C1'].AsString);
 end;
 
 initialization


### PR DESCRIPTION
Fixes #6.

## Problem

Setting a cell to an empty string (`Cell.AsString := ''`) produced `<c t="s"><v>-1</v></c>` in the generated sheet XML. `BuildSharedStrings` deliberately excludes empty strings from the sharedStrings table, but `GenerateSheet` still looked them up, so `IndexOf` returned -1 — an invalid sharedStrings index. Excel reports the file as corrupt ("Removed records: cell information from sheet1.xml") and silently drops the affected cells.

## Fix

Empty string cells are now written the same way as `TCellType.Empty` cells: a self-closing `<c r=".." s=".."/>` element when the cell carries a style, and nothing at all when it doesn't. No sharedStrings lookup takes place for empty strings anymore.

## Tests

- `SaveToFile_EmptyStringCell_WritesNoInvalidSharedStringIndex` — asserts the generated sheet XML contains no `<v>-1</v>`, omits unstyled empty cells and writes styled empty cells without a shared-string reference. Verified to fail on `main` before the fix.
- `RoundTrip_EmptyStringCell_PreservesAdjacentValues` — save/load round trip with an empty cell between two filled cells.

Full suite: 178 tests, 0 failures, 0 leaks.
