### PR TITLE
Use locale-aware date formats and honour custom NumberFormat on date cells

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -1047,10 +1047,17 @@ begin
   var FontSizeStr := '';
   if Cell.FFontSize <> 0 then
     FontSizeStr := FormatFloat('0.##', Cell.FFontSize, TFormatSettings.Invariant);
+  // 0 = no date format, 1 = date only (built-in numFmtId 14), 2 = date with time (built-in numFmtId 22)
+  var DateFlag := 0;
+  if Cell.CellType = TCellType.DateTime then
+    if Frac(Cell.FDateTimeValue) <> 0 then
+      DateFlag := 2
+    else
+      DateFlag := 1;
   Result := Format('%d|%d|%d|%s|%d|%d|%s|%s|%d|%d|%d|%d|%d', [
     Ord(Cell.FBold),
     Cell.FBackgroundColor,
-    Ord(Cell.CellType = TCellType.DateTime),
+    DateFlag,
     Cell.FNumberFormat,
     Ord(Cell.FItalic),
     Ord(Cell.FUnderline),
@@ -1171,12 +1178,15 @@ begin
     SB.Append(XmlDeclaration);
     SB.Append('<styleSheet xmlns="' + SpreadsheetNs + '">');
 
-    const NumFmtCount = 1 + NumFormats.Count;
-    SB.Append('<numFmts count="' + IntToStr(NumFmtCount) + '">');
-    SB.Append('<numFmt numFmtId="164" formatCode="yyyy-mm-dd"/>');
-    for var I := 0 to NumFormats.Count - 1 do
-      SB.Append('<numFmt numFmtId="' + IntToStr(165 + I) + '" formatCode="' + EscapeXml(NumFormats[I]) + '"/>');
-    SB.Append('</numFmts>');
+    // Date cells use the built-in locale-aware formats (14 = short date, 22 = date + time),
+    // so only user-supplied custom formats need numFmt entries. Custom ids start at 165.
+    if NumFormats.Count > 0 then
+    begin
+      SB.Append('<numFmts count="' + IntToStr(NumFormats.Count) + '">');
+      for var I := 0 to NumFormats.Count - 1 do
+        SB.Append('<numFmt numFmtId="' + IntToStr(165 + I) + '" formatCode="' + EscapeXml(NumFormats[I]) + '"/>');
+      SB.Append('</numFmts>');
+    end;
 
     const FontCount = 1 + FontKeys.Count;
     SB.Append('<fonts count="' + IntToStr(FontCount) + '">');
@@ -1256,7 +1266,7 @@ begin
         const Parts = StylePair.Key.Split(['|']);
         const IsBold = Parts[0] = '1';
         const BgColor = StrToIntDef(Parts[1], 0);
-        const IsDate = Parts[2] = '1';
+        const DateFlag = StrToIntDef(Parts[2], 0);
         const CustomFormat = Parts[3];
         const IsItalic = Parts[4] = '1';
         const IsUnderline = Parts[5] = '1';
@@ -1283,11 +1293,15 @@ begin
         if BorderKey <> '0|0' then
           BorderId := 1 + BorderKeys.IndexOf(BorderKey);
 
+        // A user-supplied NumberFormat overrides the default date format, so custom
+        // formats also work on date cells.
         var NumFmtId := 0;
-        if IsDate then
-          NumFmtId := 164
-        else if CustomFormat <> '' then
-          NumFmtId := 165 + NumFormats.IndexOf(CustomFormat);
+        if CustomFormat <> '' then
+          NumFmtId := 165 + NumFormats.IndexOf(CustomFormat)
+        else if DateFlag = 1 then
+          NumFmtId := 14
+        else if DateFlag = 2 then
+          NumFmtId := 22;
 
         var ApplyAttrs := '';
         if NumFmtId <> 0 then ApplyAttrs := ApplyAttrs + ' applyNumberFormat="1"';

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -170,6 +170,18 @@ type
 
     [Test]
     procedure RoundTrip_EmptyStringCell_PreservesAdjacentValues;
+
+    [Test]
+    procedure SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;
+
+    [Test]
+    procedure SaveToFile_DateTimeCellWithTime_UsesLocaleAwareDateTimeFormat;
+
+    [Test]
+    procedure SaveToFile_DateTimeCellWithNumberFormat_UsesCustomFormat;
+
+    [Test]
+    procedure RoundTrip_DateTimeWithTime_PreservesValue;
   end;
 
 implementation
@@ -404,8 +416,8 @@ begin
     Assert.IsTrue(Package.PartExists('xl/styles.xml'), 'Should contain xl/styles.xml');
 
     const StylesXml = Package.GetPartContent('xl/styles.xml');
-    Assert.IsTrue(Pos('numFmt', StylesXml) > 0, 'Should contain number format');
-    Assert.IsTrue(Pos('yyyy-mm-dd', StylesXml) > 0, 'Should contain date format code');
+    Assert.IsTrue(Pos('<styleSheet', StylesXml) > 0, 'Should contain styleSheet element');
+    Assert.IsTrue(Pos('<cellXfs', StylesXml) > 0, 'Should contain cellXfs element');
   finally
     Package.Free;
   end;
@@ -1047,6 +1059,73 @@ begin
   Assert.AreEqual('Left', Workbook2.Sheets[0].Cell['A1'].AsString);
   Assert.AreEqual('', Workbook2.Sheets[0].Cell['B1'].AsString);
   Assert.AreEqual('Right', Workbook2.Sheets[0].Cell['C1'].AsString);
+end;
+
+procedure TExcelWriteTests.SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsDateTime := EncodeDate(2024, 6, 15);
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    Assert.IsTrue(Pos('numFmtId="14"', StylesXml) > 0, 'Date cell should use built-in locale-aware short date format 14');
+    Assert.IsFalse(Pos('yyyy-mm-dd', StylesXml) > 0, 'Should not contain a hardcoded date format code');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.SaveToFile_DateTimeCellWithTime_UsesLocaleAwareDateTimeFormat;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsDateTime := EncodeDate(2024, 6, 15) + EncodeTime(14, 30, 0, 0);
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    Assert.IsTrue(Pos('numFmtId="22"', StylesXml) > 0, 'Date cell with time should use built-in locale-aware date/time format 22');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.SaveToFile_DateTimeCellWithNumberFormat_UsesCustomFormat;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsDateTime := EncodeDate(2024, 6, 15) + EncodeTime(14, 30, 0, 0);
+  Sheet.Cell['A1'].NumberFormat := 'dd.mm.yyyy hh:mm';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    Assert.IsTrue(Pos('formatCode="dd.mm.yyyy hh:mm"', StylesXml) > 0, 'Custom number format should be written');
+    Assert.IsTrue(Pos('numFmtId="165"', StylesXml) > 0, 'Custom format should be referenced by the cell style');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.RoundTrip_DateTimeWithTime_PreservesValue;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const TestValue = EncodeDate(2024, 6, 15) + EncodeTime(14, 30, 45, 0);
+  Sheet.Cell['A1'].AsDateTime := TestValue;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual(Double(TestValue), Double(Workbook2.Sheets[0].Cell['A1'].AsDateTime), 1E-8);
 end;
 
 initialization


### PR DESCRIPTION
Fixes #5.

## Problem

1. Date cells were always written with a hardcoded custom format (`numFmtId="164" formatCode="yyyy-mm-dd"`), so Excel displayed every date as `yyyy-mm-dd` regardless of the user's locale — on a German system the expected `TT.MM.JJJJ` never appeared.
2. A user-supplied `NumberFormat` on a date cell was ignored: the date format always took priority, so there was no way to control how a date is displayed.

## Fix

- Date cells now use Excel's **built-in locale-aware number formats**: id **14** (short date) for date-only values and id **22** (date + time) for values with a time part. Excel renders these according to the viewing system's regional settings, so a German system automatically shows `TT.MM.JJJJ`.
- A custom `NumberFormat` now **overrides** the default date format, so `Cell.NumberFormat := 'dd.mm.yyyy hh:mm'` works on date cells.
- The `<numFmts>` block is only emitted when custom formats are present; built-in ids need no definition.

Note for #5: format codes in `NumberFormat` must use the **English** OOXML format letters (`dd`, `mm`, `yyyy`, `hh`) — locale-specific letters like `TT.MM.JJJJ` are display-only aliases in Excel's UI and are invalid in the file format itself, which is why they produced a repair message.

## Tests

- `SaveToFile_DateCell_UsesLocaleAwareShortDateFormat` — date-only cell references numFmtId 14, no hardcoded format code left
- `SaveToFile_DateTimeCellWithTime_UsesLocaleAwareDateTimeFormat` — date+time cell references numFmtId 22
- `SaveToFile_DateTimeCellWithNumberFormat_UsesCustomFormat` — custom format is written and referenced
- `RoundTrip_DateTimeWithTime_PreservesValue` — value survives save/load including time part

Full suite: 182 tests, 0 failures, 0 leaks.
