### PR TITLE
Fix sharedStrings index misalignment on empty and rich-text entries

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -1357,10 +1357,22 @@ end;
 procedure TExcelWorkbook.ParseSharedStrings(const Xml: string);
 begin
   FSharedStrings.Clear;
-  const Matches = TRegEx.Matches(Xml, '<si>.*?<t[^>]*>([^<]*)</t>.*?</si>', [roIgnoreCase, roSingleLine]);
-  for var Match in Matches do
-    if Match.Groups.Count > 1 then
-      FSharedStrings.Add(Match.Groups[1].Value);
+  // Every <si> occupies exactly one index slot, including empty entries (<si><t/></si>)
+  // and rich-text entries (<si><r><t>..</t></r><r><t>..</t></r></si>). Matching across
+  // si boundaries shifts all subsequent indices, mapping cells to the wrong strings.
+  const SiMatches = TRegEx.Matches(Xml, '<si>(.*?)</si>', [roIgnoreCase, roSingleLine]);
+  for var SiMatch in SiMatches do
+    if SiMatch.Groups.Count > 1 then
+    begin
+      // Phonetic guide blocks carry their own <t> elements that are not part of the text.
+      const SiXml = TRegEx.Replace(SiMatch.Groups[1].Value, '<rPh\s[^>]*>.*?</rPh>', '', [roIgnoreCase, roSingleLine]);
+      var Text := '';
+      const TextMatches = TRegEx.Matches(SiXml, '<t(?:\s[^>]*)?>([^<]*)</t>', [roIgnoreCase]);
+      for var TextMatch in TextMatches do
+        if TextMatch.Groups.Count > 1 then
+          Text := Text + TextMatch.Groups[1].Value;
+      FSharedStrings.Add(Text);
+    end;
 end;
 
 procedure TExcelWorkbook.ParseStyles(const Xml: string);

--- a/Tests/Source/Office4D.Tests.Excel.pas
+++ b/Tests/Source/Office4D.Tests.Excel.pas
@@ -5,6 +5,7 @@ interface
 uses
   System.SysUtils,
   System.IOUtils,
+  System.Zip,
   System.Generics.Collections,
   DUnitX.TestFramework,
   Office4D.Tests.Samples,
@@ -109,6 +110,26 @@ type
 
     [Test]
     procedure Cell_Formula_WhenNoFormula_ReturnsEmpty;
+  end;
+
+  [TestFixture]
+  TExcelSharedStringsTests = class
+  private
+    FTempFile: string;
+
+    procedure WriteWorkbookWithSharedStrings(const SharedStringsXml: string);
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Load_EmptySharedStringEntry_KeepsIndexAlignment;
+
+    [Test]
+    procedure Load_RichTextSharedString_ConcatenatesRuns;
   end;
 
   [TestFixture]
@@ -667,11 +688,90 @@ begin
   Assert.AreEqual(Double(30), Sheet.GetColumnWidth('C'), 'Layout col C width');
 end;
 
+{ TExcelSharedStringsTests }
+
+procedure TExcelSharedStringsTests.Setup;
+begin
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'test_sst_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelSharedStringsTests.TearDown;
+begin
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TExcelSharedStringsTests.WriteWorkbookWithSharedStrings(const SharedStringsXml: string);
+const
+  XmlDecl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+  SpreadsheetNs = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+begin
+  const WorkbookXml = XmlDecl +
+    '<workbook xmlns="' + SpreadsheetNs + '"><sheets><sheet name="Sheet1" sheetId="1"/></sheets></workbook>';
+  const SheetXml = XmlDecl +
+    '<worksheet xmlns="' + SpreadsheetNs + '"><sheetData><row r="1">' +
+    '<c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c>' +
+    '<c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>3</v></c>' +
+    '</row></sheetData></worksheet>';
+
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(FTempFile, zmWrite);
+    Zip.Add(TEncoding.UTF8.GetBytes(WorkbookXml), 'xl/workbook.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(XmlDecl + SharedStringsXml), 'xl/sharedStrings.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(SheetXml), 'xl/worksheets/sheet1.xml');
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+end;
+
+procedure TExcelSharedStringsTests.Load_EmptySharedStringEntry_KeepsIndexAlignment;
+begin
+  WriteWorkbookWithSharedStrings(
+    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">' +
+    '<si><t>First</t></si>' +
+    '<si><t/></si>' +
+    '<si><t>Third</t></si>' +
+    '<si><t xml:space="preserve">Fourth</t></si>' +
+    '</sst>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  const Sheet = Workbook.Sheets[0];
+  Assert.AreEqual('First', Sheet.Cell['A1'].AsString, 'A1 should map to entry 0');
+  Assert.AreEqual('', Sheet.Cell['B1'].AsString, 'B1 should map to the empty entry 1');
+  Assert.AreEqual('Third', Sheet.Cell['C1'].AsString, 'C1 should map to entry 2');
+  Assert.AreEqual('Fourth', Sheet.Cell['D1'].AsString, 'D1 should map to entry 3');
+end;
+
+procedure TExcelSharedStringsTests.Load_RichTextSharedString_ConcatenatesRuns;
+begin
+  WriteWorkbookWithSharedStrings(
+    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">' +
+    '<si><t>Plain</t></si>' +
+    '<si><r><rPr><b/></rPr><t>Rich</t></r><r><t xml:space="preserve"> Text</t></r></si>' +
+    '<si><t>After</t></si>' +
+    '<si><t>Last</t></si>' +
+    '</sst>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  const Sheet = Workbook.Sheets[0];
+  Assert.AreEqual('Plain', Sheet.Cell['A1'].AsString, 'A1 should map to entry 0');
+  Assert.AreEqual('Rich Text', Sheet.Cell['B1'].AsString, 'B1 should concatenate all rich text runs');
+  Assert.AreEqual('After', Sheet.Cell['C1'].AsString, 'C1 should map to entry 2');
+  Assert.AreEqual('Last', Sheet.Cell['D1'].AsString, 'D1 should map to entry 3');
+end;
+
 initialization
   TDUnitX.RegisterTestFixture(TExcelReadTests);
   TDUnitX.RegisterTestFixture(TExcelDOMTests);
   TDUnitX.RegisterTestFixture(TExcelAdvancedTests);
   TDUnitX.RegisterTestFixture(TExcelFormulaTests);
   TDUnitX.RegisterTestFixture(TExcelLayoutTests);
+  TDUnitX.RegisterTestFixture(TExcelSharedStringsTests);
 
 end.


### PR DESCRIPTION
Fixes #9.

**Problem:** `ParseSharedStrings` matched the whole sharedStrings XML with one regex that requires a non-empty `<t>...</t>` per entry. Excel writes empty strings as self-closing `<si><t/></si>` — the regex then swallows the *next* entry, shifting every index after it. Result: cells resolve to the wrong strings (the exact symptom in #9). Rich-text entries also lost everything after their first text run.

**Fix:** each `<si>` is parsed individually, so every entry keeps its index slot: empty entries yield `''`, rich-text runs are concatenated, phonetic blocks are ignored.

**Tests:** new `TExcelSharedStringsTests` with hand-crafted sharedStrings parts. Both tests fail on the old parser (`Expected [] but got [Third]` — the #9 shift) and pass with the fix. Full suite: 184 tests, 0 failures.
