### PR TITLE
Add PowerPoint (.pptx) support and centralise XML escaping (DRY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Office4D
 
-Pure Delphi library for reading and writing Microsoft Office Open XML documents (.docx, .xlsx).
+Pure Delphi library for reading and writing Microsoft Office Open XML documents (.docx, .xlsx, .pptx).
 
 ## Features
 
@@ -16,7 +16,7 @@ Pure Delphi library for reading and writing Microsoft Office Open XML documents 
 |--------|-----------|------|-------|
 | Word | .docx | Yes | Yes |
 | Excel | .xlsx | Yes | Yes |
-| PowerPoint | .pptx | Planned | Planned |
+| PowerPoint | .pptx | Text extraction | Yes (basic) |
 
 ## Installation
 
@@ -247,6 +247,7 @@ Source/
   Common/      - Metadata, shared interfaces
   Word/        - Word document implementation
   Excel/       - Excel workbook implementation
+  PowerPoint/  - PowerPoint presentation implementation
 Tests/
   Source/      - DUnitX test suite
   Samples/     - Sample documents for testing
@@ -277,6 +278,25 @@ Examples/      - Demo application
 - Merged cells
 - Shared strings optimization
 - Metadata (author, title, dates)
+
+## PowerPoint Features
+
+- Creating presentations with multiple slides
+- Slide titles and body text with paragraphs
+- Bullet lists with indent levels
+- Run formatting: bold, italic, underline, font name, size, color
+- Reading text back from presentations (title, paragraphs, formatting)
+- Metadata (author, title, dates)
+
+```pascal
+uses Office4D.PowerPoint;
+
+var Presentation := TPowerPointPresentationFactory.CreatePresentation;
+var Slide := Presentation.AddSlide('Quarterly Report');
+var Bullet := Slide.AddParagraph('Revenue up 12%');
+Bullet.Bullet := True;
+Presentation.SaveToFile('report.pptx');
+```
 
 ## Requirements
 

--- a/Source/Core/Office4D.Xml.pas
+++ b/Source/Core/Office4D.Xml.pas
@@ -1,0 +1,44 @@
+unit Office4D.Xml;
+
+interface
+
+type
+  /// <summary>
+  /// Shared XML text helpers used by the Word, Excel and PowerPoint modules.
+  /// Escape is applied when writing element/attribute text, Unescape when
+  /// reading it back, so text round-trips through the five predefined entities.
+  /// </summary>
+  TXml = record
+  public
+    class function Escape(const Value: string): string; static;
+    class function Unescape(const Value: string): string; static;
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+class function TXml.Escape(const Value: string): string;
+begin
+  Result := Value;
+  // & must be replaced first so the entities added below are not re-escaped.
+  Result := StringReplace(Result, '&', '&amp;', [rfReplaceAll]);
+  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
+  Result := StringReplace(Result, '''', '&apos;', [rfReplaceAll]);
+end;
+
+class function TXml.Unescape(const Value: string): string;
+begin
+  Result := Value;
+  Result := StringReplace(Result, '&lt;', '<', [rfReplaceAll]);
+  Result := StringReplace(Result, '&gt;', '>', [rfReplaceAll]);
+  Result := StringReplace(Result, '&quot;', '"', [rfReplaceAll]);
+  Result := StringReplace(Result, '&apos;', '''', [rfReplaceAll]);
+  // &amp; must be decoded last so escaped entities like &amp;lt; survive intact.
+  Result := StringReplace(Result, '&amp;', '&', [rfReplaceAll]);
+end;
+
+end.

--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -143,7 +143,6 @@ type
 
     function BuildSharedStrings: TList<string>;
     function GetSharedStringIndex(const Strings: TList<string>; const Value: string): Integer;
-    function EscapeXml(const Text: string): string;
     function AdjustFormulaRefs(const Formula: string; const RowDelta, ColDelta: Integer): string;
     function GenerateContentTypes: string;
     function GenerateRels: string;
@@ -180,7 +179,8 @@ uses
   System.StrUtils,
   Office4D.Errors,
   Office4D.Relationships,
-  Office4D.Types;
+  Office4D.Types,
+  Office4D.Xml;
 
 const
   // Default OOXML indexed colour palette (indices 0-63). Indices 0-7 are redundant
@@ -774,16 +774,6 @@ begin
   Result := Strings.IndexOf(Value);
 end;
 
-function TExcelWorkbook.EscapeXml(const Text: string): string;
-begin
-  Result := Text;
-  Result := StringReplace(Result, '&', '&amp;', [rfReplaceAll]);
-  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
-  Result := StringReplace(Result, '''', '&apos;', [rfReplaceAll]);
-end;
-
 function TExcelWorkbook.GenerateContentTypes: string;
 begin
   var SB := TStringBuilder.Create;
@@ -1034,7 +1024,7 @@ begin
     SB.Append(XmlDeclaration);
     SB.Append('<sst xmlns="' + SpreadsheetNs + '" count="' + IntToStr(Strings.Count) + '" uniqueCount="' + IntToStr(Strings.Count) + '">');
     for var StringItem in Strings do
-      SB.Append('<si><t>' + StringItem + '</t></si>');
+      SB.Append('<si><t>' + TXml.Escape(StringItem) + '</t></si>');
     SB.Append('</sst>');
     Result := SB.ToString;
   finally
@@ -1184,7 +1174,7 @@ begin
     begin
       SB.Append('<numFmts count="' + IntToStr(NumFormats.Count) + '">');
       for var I := 0 to NumFormats.Count - 1 do
-        SB.Append('<numFmt numFmtId="' + IntToStr(165 + I) + '" formatCode="' + EscapeXml(NumFormats[I]) + '"/>');
+        SB.Append('<numFmt numFmtId="' + IntToStr(165 + I) + '" formatCode="' + TXml.Escape(NumFormats[I]) + '"/>');
       SB.Append('</numFmts>');
     end;
 
@@ -1208,7 +1198,7 @@ begin
       else
         SB.Append('<sz val="11"/>');
       if Name <> '' then
-        SB.Append('<name val="' + EscapeXml(Name) + '"/>')
+        SB.Append('<name val="' + TXml.Escape(Name) + '"/>')
       else
         SB.Append('<name val="Calibri"/>');
       SB.Append('</font>');
@@ -1370,7 +1360,7 @@ begin
       const TextMatches = TRegEx.Matches(SiXml, '<t(?:\s[^>]*)?>([^<]*)</t>', [roIgnoreCase]);
       for var TextMatch in TextMatches do
         if TextMatch.Groups.Count > 1 then
-          Text := Text + TextMatch.Groups[1].Value;
+          Text := Text + TXml.Unescape(TextMatch.Groups[1].Value);
       FSharedStrings.Add(Text);
     end;
 end;

--- a/Source/PowerPoint/Office4D.PowerPoint.Presentation.pas
+++ b/Source/PowerPoint/Office4D.PowerPoint.Presentation.pas
@@ -96,7 +96,6 @@ type
     function GenerateSlideRelsXml: string;
     function GenerateParagraphXml(const Paragraph: IPowerPointParagraph): string;
     function GenerateRunXml(const Run: IPowerPointRun): string;
-    function EscapeXml(const Text: string): string;
 
     procedure ParsePackage;
     procedure ParseSlideXml(const Xml: string);
@@ -123,7 +122,8 @@ implementation
 
 uses
   System.RegularExpressions,
-  Office4D.Relationships;
+  Office4D.Relationships,
+  Office4D.Xml;
 
 const
   XmlDeclaration = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -636,7 +636,7 @@ begin
       SB.Append('<p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>');
       SB.Append('<p:spPr/>');
       SB.Append('<p:txBody><a:bodyPr/><a:lstStyle/>');
-      SB.Append('<a:p><a:r><a:rPr lang="en-US" dirty="0"/><a:t>' + EscapeXml(Slide.Title) + '</a:t></a:r></a:p>');
+      SB.Append('<a:p><a:r><a:rPr lang="en-US" dirty="0"/><a:t>' + TXml.Escape(Slide.Title) + '</a:t></a:r></a:p>');
       SB.Append('</p:txBody>');
       SB.Append('</p:sp>');
     end;
@@ -718,9 +718,9 @@ begin
 
   var Children := '';
   if Run.FontColor <> '' then
-    Children := Children + '<a:solidFill><a:srgbClr val="' + EscapeXml(Run.FontColor) + '"/></a:solidFill>';
+    Children := Children + '<a:solidFill><a:srgbClr val="' + TXml.Escape(Run.FontColor) + '"/></a:solidFill>';
   if Run.FontName <> '' then
-    Children := Children + '<a:latin typeface="' + EscapeXml(Run.FontName) + '"/>';
+    Children := Children + '<a:latin typeface="' + TXml.Escape(Run.FontName) + '"/>';
 
   var RPr := '';
   if Children = '' then
@@ -728,17 +728,7 @@ begin
   else
     RPr := '<a:rPr' + Attrs + '>' + Children + '</a:rPr>';
 
-  Result := '<a:r>' + RPr + '<a:t>' + EscapeXml(Run.Text) + '</a:t></a:r>';
-end;
-
-function TPowerPointPresentation.EscapeXml(const Text: string): string;
-begin
-  Result := Text;
-  Result := StringReplace(Result, '&', '&amp;', [rfReplaceAll]);
-  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
-  Result := StringReplace(Result, '''', '&apos;', [rfReplaceAll]);
+  Result := '<a:r>' + RPr + '<a:t>' + TXml.Escape(Run.Text) + '</a:t></a:r>';
 end;
 
 procedure TPowerPointPresentation.LoadFromFile(const FileName: string);
@@ -834,7 +824,7 @@ begin
         var Title := '';
         const TextMatches = TRegEx.Matches(SpXml, '<a:t>([^<]*)</a:t>', [roIgnoreCase]);
         for var TextMatch in TextMatches do
-          Title := Title + TextMatch.Groups[1].Value;
+          Title := Title + TXml.Unescape(TextMatch.Groups[1].Value);
         Slide.Title := Title;
       end
       else
@@ -867,7 +857,7 @@ begin
       if not TextMatch.Success then
         Continue;
 
-      const Run = Paragraph.AddRun(TextMatch.Groups[1].Value);
+      const Run = Paragraph.AddRun(TXml.Unescape(TextMatch.Groups[1].Value));
 
       const RPrMatch = TRegEx.Match(RunXml, '<a:rPr([^>]*?)(?:/>|>(.*?)</a:rPr>)', [roIgnoreCase, roSingleLine]);
       if RPrMatch.Success then

--- a/Source/PowerPoint/Office4D.PowerPoint.Presentation.pas
+++ b/Source/PowerPoint/Office4D.PowerPoint.Presentation.pas
@@ -1,0 +1,899 @@
+unit Office4D.PowerPoint.Presentation;
+
+interface
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.Zip,
+  System.Generics.Collections,
+  Office4D.PowerPoint,
+  Office4D.Metadata,
+  Office4D.Package;
+
+type
+  TPowerPointRun = class(TInterfacedObject, IPowerPointRun)
+  private
+    FText: string;
+    FBold: Boolean;
+    FItalic: Boolean;
+    FUnderline: Boolean;
+    FFontName: string;
+    FFontSize: Integer;
+    FFontColor: string;
+
+    function GetText: string;
+    procedure SetText(const Value: string);
+    function GetBold: Boolean;
+    procedure SetBold(const Value: Boolean);
+    function GetItalic: Boolean;
+    procedure SetItalic(const Value: Boolean);
+    function GetUnderline: Boolean;
+    procedure SetUnderline(const Value: Boolean);
+    function GetFontName: string;
+    procedure SetFontName(const Value: string);
+    function GetFontSize: Integer;
+    procedure SetFontSize(const Value: Integer);
+    function GetFontColor: string;
+    procedure SetFontColor(const Value: string);
+  end;
+
+  TPowerPointParagraph = class(TInterfacedObject, IPowerPointParagraph)
+  private
+    FRuns: TList<IPowerPointRun>;
+    FBullet: Boolean;
+    FIndentLevel: Integer;
+
+    function GetText: string;
+    function GetRunCount: Integer;
+    function GetRun(Index: Integer): IPowerPointRun;
+    function GetBullet: Boolean;
+    procedure SetBullet(const Value: Boolean);
+    function GetIndentLevel: Integer;
+    procedure SetIndentLevel(const Value: Integer);
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function AddRun(const Text: string): IPowerPointRun;
+  end;
+
+  TPowerPointSlide = class(TInterfacedObject, IPowerPointSlide)
+  private
+    FTitle: string;
+    FParagraphs: TList<IPowerPointParagraph>;
+
+    function GetTitle: string;
+    procedure SetTitle(const Value: string);
+    function GetText: string;
+    function GetParagraphCount: Integer;
+    function GetParagraph(Index: Integer): IPowerPointParagraph;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function AddParagraph: IPowerPointParagraph; overload;
+    function AddParagraph(const Text: string): IPowerPointParagraph; overload;
+  end;
+
+  TPowerPointPresentation = class(TInterfacedObject, IPowerPointPresentation)
+  private
+    FSlides: TList<IPowerPointSlide>;
+    FMetadata: TDocumentMetadata;
+    FPackage: TOXMLPackage;
+
+    procedure AddPartsToZip(const Zip: TZipFile);
+    function GenerateContentTypesXml: string;
+    function GenerateRootRelsXml: string;
+    function GeneratePresentationXml: string;
+    function GeneratePresentationRelsXml: string;
+    function GenerateSlideMasterXml: string;
+    function GenerateSlideMasterRelsXml: string;
+    function GenerateSlideLayoutXml: string;
+    function GenerateSlideLayoutRelsXml: string;
+    function GenerateThemeXml: string;
+    function GenerateSlideXml(const Slide: IPowerPointSlide): string;
+    function GenerateSlideRelsXml: string;
+    function GenerateParagraphXml(const Paragraph: IPowerPointParagraph): string;
+    function GenerateRunXml(const Run: IPowerPointRun): string;
+    function EscapeXml(const Text: string): string;
+
+    procedure ParsePackage;
+    procedure ParseSlideXml(const Xml: string);
+    procedure ParseParagraphXml(const Xml: string; const Slide: IPowerPointSlide);
+
+    function GetText: string;
+    function GetMetadata: TDocumentMetadata;
+    function GetSlideCount: Integer;
+    function GetSlide(Index: Integer): IPowerPointSlide;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    procedure LoadFromFile(const FileName: string);
+    procedure LoadFromStream(const Stream: TStream);
+    procedure SaveToFile(const FileName: string);
+    procedure SaveToStream(const Stream: TStream);
+
+    function AddSlide: IPowerPointSlide; overload;
+    function AddSlide(const Title: string): IPowerPointSlide; overload;
+  end;
+
+implementation
+
+uses
+  System.RegularExpressions,
+  Office4D.Relationships;
+
+const
+  XmlDeclaration = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+  ContentTypesNs = 'http://schemas.openxmlformats.org/package/2006/content-types';
+  RelationshipsNs = 'http://schemas.openxmlformats.org/package/2006/relationships';
+  PresentationMLNs = 'http://schemas.openxmlformats.org/presentationml/2006/main';
+  DrawingMLNs = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  DocRelationshipsNs = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+  RelTypeOfficeDocument = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+  RelTypeSlide = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide';
+  RelTypeSlideMaster = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster';
+  RelTypeSlideLayout = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout';
+  RelTypeTheme = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
+
+  PartRootRels = '_rels/.rels';
+  PartPresentation = 'ppt/presentation.xml';
+  PartPresentationRels = 'ppt/_rels/presentation.xml.rels';
+  PartSlideMaster = 'ppt/slideMasters/slideMaster1.xml';
+  PartSlideMasterRels = 'ppt/slideMasters/_rels/slideMaster1.xml.rels';
+  PartSlideLayout = 'ppt/slideLayouts/slideLayout1.xml';
+  PartSlideLayoutRels = 'ppt/slideLayouts/_rels/slideLayout1.xml.rels';
+  PartTheme = 'ppt/theme/theme1.xml';
+  PartCoreProps = 'docProps/core.xml';
+  PartPptPrefix = 'ppt/';
+
+  SlideXmlnsAttrs = ' xmlns:a="' + DrawingMLNs + '" xmlns:r="' + DocRelationshipsNs + '" xmlns:p="' + PresentationMLNs + '"';
+  BulletChar = '&#8226;';
+
+{ TPowerPointRun }
+
+function TPowerPointRun.GetText: string;
+begin
+  Result := FText;
+end;
+
+procedure TPowerPointRun.SetText(const Value: string);
+begin
+  FText := Value;
+end;
+
+function TPowerPointRun.GetBold: Boolean;
+begin
+  Result := FBold;
+end;
+
+procedure TPowerPointRun.SetBold(const Value: Boolean);
+begin
+  FBold := Value;
+end;
+
+function TPowerPointRun.GetItalic: Boolean;
+begin
+  Result := FItalic;
+end;
+
+procedure TPowerPointRun.SetItalic(const Value: Boolean);
+begin
+  FItalic := Value;
+end;
+
+function TPowerPointRun.GetUnderline: Boolean;
+begin
+  Result := FUnderline;
+end;
+
+procedure TPowerPointRun.SetUnderline(const Value: Boolean);
+begin
+  FUnderline := Value;
+end;
+
+function TPowerPointRun.GetFontName: string;
+begin
+  Result := FFontName;
+end;
+
+procedure TPowerPointRun.SetFontName(const Value: string);
+begin
+  FFontName := Value;
+end;
+
+function TPowerPointRun.GetFontSize: Integer;
+begin
+  Result := FFontSize;
+end;
+
+procedure TPowerPointRun.SetFontSize(const Value: Integer);
+begin
+  FFontSize := Value;
+end;
+
+function TPowerPointRun.GetFontColor: string;
+begin
+  Result := FFontColor;
+end;
+
+procedure TPowerPointRun.SetFontColor(const Value: string);
+begin
+  FFontColor := Value;
+end;
+
+{ TPowerPointParagraph }
+
+constructor TPowerPointParagraph.Create;
+begin
+  inherited Create;
+  FRuns := TList<IPowerPointRun>.Create;
+end;
+
+destructor TPowerPointParagraph.Destroy;
+begin
+  FRuns.Free;
+  inherited;
+end;
+
+function TPowerPointParagraph.GetText: string;
+begin
+  Result := '';
+  for var Run in FRuns do
+    Result := Result + Run.Text;
+end;
+
+function TPowerPointParagraph.GetRunCount: Integer;
+begin
+  Result := FRuns.Count;
+end;
+
+function TPowerPointParagraph.GetRun(Index: Integer): IPowerPointRun;
+begin
+  Result := FRuns[Index];
+end;
+
+function TPowerPointParagraph.AddRun(const Text: string): IPowerPointRun;
+begin
+  Result := TPowerPointRun.Create;
+  Result.Text := Text;
+  FRuns.Add(Result);
+end;
+
+function TPowerPointParagraph.GetBullet: Boolean;
+begin
+  Result := FBullet;
+end;
+
+procedure TPowerPointParagraph.SetBullet(const Value: Boolean);
+begin
+  FBullet := Value;
+end;
+
+function TPowerPointParagraph.GetIndentLevel: Integer;
+begin
+  Result := FIndentLevel;
+end;
+
+procedure TPowerPointParagraph.SetIndentLevel(const Value: Integer);
+begin
+  FIndentLevel := Value;
+end;
+
+{ TPowerPointSlide }
+
+constructor TPowerPointSlide.Create;
+begin
+  inherited Create;
+  FParagraphs := TList<IPowerPointParagraph>.Create;
+end;
+
+destructor TPowerPointSlide.Destroy;
+begin
+  FParagraphs.Free;
+  inherited;
+end;
+
+function TPowerPointSlide.GetTitle: string;
+begin
+  Result := FTitle;
+end;
+
+procedure TPowerPointSlide.SetTitle(const Value: string);
+begin
+  FTitle := Value;
+end;
+
+function TPowerPointSlide.GetText: string;
+begin
+  Result := FTitle;
+  for var Paragraph in FParagraphs do
+  begin
+    if Result <> '' then
+      Result := Result + sLineBreak;
+    Result := Result + Paragraph.Text;
+  end;
+end;
+
+function TPowerPointSlide.GetParagraphCount: Integer;
+begin
+  Result := FParagraphs.Count;
+end;
+
+function TPowerPointSlide.GetParagraph(Index: Integer): IPowerPointParagraph;
+begin
+  Result := FParagraphs[Index];
+end;
+
+function TPowerPointSlide.AddParagraph: IPowerPointParagraph;
+begin
+  Result := TPowerPointParagraph.Create;
+  FParagraphs.Add(Result);
+end;
+
+function TPowerPointSlide.AddParagraph(const Text: string): IPowerPointParagraph;
+begin
+  Result := AddParagraph;
+  Result.AddRun(Text);
+end;
+
+{ TPowerPointPresentation }
+
+constructor TPowerPointPresentation.Create;
+begin
+  inherited Create;
+  FSlides := TList<IPowerPointSlide>.Create;
+  FMetadata.Clear;
+  FPackage := nil;
+end;
+
+destructor TPowerPointPresentation.Destroy;
+begin
+  FreeAndNil(FPackage);
+  FSlides.Free;
+  inherited;
+end;
+
+function TPowerPointPresentation.AddSlide: IPowerPointSlide;
+begin
+  Result := TPowerPointSlide.Create;
+  FSlides.Add(Result);
+end;
+
+function TPowerPointPresentation.AddSlide(const Title: string): IPowerPointSlide;
+begin
+  Result := AddSlide;
+  Result.Title := Title;
+end;
+
+function TPowerPointPresentation.GetSlideCount: Integer;
+begin
+  Result := FSlides.Count;
+end;
+
+function TPowerPointPresentation.GetSlide(Index: Integer): IPowerPointSlide;
+begin
+  Result := FSlides[Index];
+end;
+
+function TPowerPointPresentation.GetText: string;
+begin
+  Result := '';
+  for var Slide in FSlides do
+  begin
+    if Result <> '' then
+      Result := Result + sLineBreak;
+    Result := Result + Slide.Text;
+  end;
+end;
+
+function TPowerPointPresentation.GetMetadata: TDocumentMetadata;
+begin
+  Result := FMetadata;
+end;
+
+procedure TPowerPointPresentation.SaveToFile(const FileName: string);
+begin
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(FileName, zmWrite);
+    AddPartsToZip(Zip);
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+end;
+
+procedure TPowerPointPresentation.SaveToStream(const Stream: TStream);
+begin
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(Stream, zmWrite);
+    AddPartsToZip(Zip);
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+end;
+
+procedure TPowerPointPresentation.AddPartsToZip(const Zip: TZipFile);
+begin
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateContentTypesXml), '[Content_Types].xml');
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateRootRelsXml), PartRootRels);
+  Zip.Add(TEncoding.UTF8.GetBytes(GeneratePresentationXml), PartPresentation);
+  Zip.Add(TEncoding.UTF8.GetBytes(GeneratePresentationRelsXml), PartPresentationRels);
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideMasterXml), PartSlideMaster);
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideMasterRelsXml), PartSlideMasterRels);
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideLayoutXml), PartSlideLayout);
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideLayoutRelsXml), PartSlideLayoutRels);
+  Zip.Add(TEncoding.UTF8.GetBytes(GenerateThemeXml), PartTheme);
+
+  for var I := 0 to FSlides.Count - 1 do
+  begin
+    const SlideName = 'slide' + IntToStr(I + 1);
+    Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideXml(FSlides[I])), PartPptPrefix + 'slides/' + SlideName + '.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(GenerateSlideRelsXml), PartPptPrefix + 'slides/_rels/' + SlideName + '.xml.rels');
+  end;
+end;
+
+function TPowerPointPresentation.GenerateContentTypesXml: string;
+begin
+  var SB := TStringBuilder.Create;
+  try
+    SB.Append(XmlDeclaration);
+    SB.Append('<Types xmlns="' + ContentTypesNs + '">');
+    SB.Append('<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>');
+    SB.Append('<Default Extension="xml" ContentType="application/xml"/>');
+    SB.Append('<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>');
+    SB.Append('<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>');
+    SB.Append('<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>');
+    SB.Append('<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>');
+    for var I := 0 to FSlides.Count - 1 do
+      SB.Append('<Override PartName="/ppt/slides/slide' + IntToStr(I + 1) + '.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>');
+    SB.Append('</Types>');
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function TPowerPointPresentation.GenerateRootRelsXml: string;
+begin
+  Result := XmlDeclaration +
+    '<Relationships xmlns="' + RelationshipsNs + '">' +
+    '<Relationship Id="rId1" Type="' + RelTypeOfficeDocument + '" Target="ppt/presentation.xml"/>' +
+    '</Relationships>';
+end;
+
+function TPowerPointPresentation.GeneratePresentationXml: string;
+begin
+  var SB := TStringBuilder.Create;
+  try
+    SB.Append(XmlDeclaration);
+    SB.Append('<p:presentation' + SlideXmlnsAttrs + '>');
+    SB.Append('<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>');
+    if FSlides.Count > 0 then
+    begin
+      SB.Append('<p:sldIdLst>');
+      for var I := 0 to FSlides.Count - 1 do
+        SB.Append('<p:sldId id="' + IntToStr(256 + I) + '" r:id="rId' + IntToStr(2 + I) + '"/>');
+      SB.Append('</p:sldIdLst>');
+    end;
+    SB.Append('<p:sldSz cx="12192000" cy="6858000"/>');
+    SB.Append('<p:notesSz cx="6858000" cy="9144000"/>');
+    SB.Append('</p:presentation>');
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function TPowerPointPresentation.GeneratePresentationRelsXml: string;
+begin
+  var SB := TStringBuilder.Create;
+  try
+    SB.Append(XmlDeclaration);
+    SB.Append('<Relationships xmlns="' + RelationshipsNs + '">');
+    SB.Append('<Relationship Id="rId1" Type="' + RelTypeSlideMaster + '" Target="slideMasters/slideMaster1.xml"/>');
+    for var I := 0 to FSlides.Count - 1 do
+      SB.Append('<Relationship Id="rId' + IntToStr(2 + I) + '" Type="' + RelTypeSlide + '" Target="slides/slide' + IntToStr(I + 1) + '.xml"/>');
+    SB.Append('</Relationships>');
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function TPowerPointPresentation.GenerateSlideMasterXml: string;
+begin
+  Result := XmlDeclaration +
+    '<p:sldMaster' + SlideXmlnsAttrs + '>' +
+    '<p:cSld>' +
+    '<p:bg><p:bgRef idx="1001"><a:schemeClr val="bg1"/></p:bgRef></p:bg>' +
+    '<p:spTree>' +
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+    '<p:grpSpPr/>' +
+    '</p:spTree>' +
+    '</p:cSld>' +
+    '<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2"' +
+    ' accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>' +
+    '<p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst>' +
+    '</p:sldMaster>';
+end;
+
+function TPowerPointPresentation.GenerateSlideMasterRelsXml: string;
+begin
+  Result := XmlDeclaration +
+    '<Relationships xmlns="' + RelationshipsNs + '">' +
+    '<Relationship Id="rId1" Type="' + RelTypeSlideLayout + '" Target="../slideLayouts/slideLayout1.xml"/>' +
+    '<Relationship Id="rId2" Type="' + RelTypeTheme + '" Target="../theme/theme1.xml"/>' +
+    '</Relationships>';
+end;
+
+function TPowerPointPresentation.GenerateSlideLayoutXml: string;
+begin
+  Result := XmlDeclaration +
+    '<p:sldLayout' + SlideXmlnsAttrs + ' type="obj">' +
+    '<p:cSld name="Title and Content">' +
+    '<p:spTree>' +
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+    '<p:grpSpPr/>' +
+    '<p:sp>' +
+    '<p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>' +
+    '<p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>' +
+    '<p:spPr><a:xfrm><a:off x="838200" y="365125"/><a:ext cx="10515600" cy="1325563"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>' +
+    '<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p></p:txBody>' +
+    '</p:sp>' +
+    '<p:sp>' +
+    '<p:nvSpPr><p:cNvPr id="3" name="Content 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>' +
+    '<p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>' +
+    '<p:spPr><a:xfrm><a:off x="838200" y="1825625"/><a:ext cx="10515600" cy="4351338"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>' +
+    '<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p></p:txBody>' +
+    '</p:sp>' +
+    '</p:spTree>' +
+    '</p:cSld>' +
+    '<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>' +
+    '</p:sldLayout>';
+end;
+
+function TPowerPointPresentation.GenerateSlideLayoutRelsXml: string;
+begin
+  Result := XmlDeclaration +
+    '<Relationships xmlns="' + RelationshipsNs + '">' +
+    '<Relationship Id="rId1" Type="' + RelTypeSlideMaster + '" Target="../slideMasters/slideMaster1.xml"/>' +
+    '</Relationships>';
+end;
+
+function TPowerPointPresentation.GenerateThemeXml: string;
+begin
+  Result := XmlDeclaration +
+    '<a:theme xmlns:a="' + DrawingMLNs + '" name="Office Theme">' +
+    '<a:themeElements>' +
+    '<a:clrScheme name="Office">' +
+    '<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>' +
+    '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>' +
+    '<a:dk2><a:srgbClr val="44546A"/></a:dk2>' +
+    '<a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>' +
+    '<a:accent1><a:srgbClr val="4472C4"/></a:accent1>' +
+    '<a:accent2><a:srgbClr val="ED7D31"/></a:accent2>' +
+    '<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>' +
+    '<a:accent4><a:srgbClr val="FFC000"/></a:accent4>' +
+    '<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>' +
+    '<a:accent6><a:srgbClr val="70AD47"/></a:accent6>' +
+    '<a:hlink><a:srgbClr val="0563C1"/></a:hlink>' +
+    '<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>' +
+    '</a:clrScheme>' +
+    '<a:fontScheme name="Office">' +
+    '<a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>' +
+    '<a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>' +
+    '</a:fontScheme>' +
+    '<a:fmtScheme name="Office">' +
+    '<a:fillStyleLst>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '</a:fillStyleLst>' +
+    '<a:lnStyleLst>' +
+    '<a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+    '<a:ln w="12700"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+    '<a:ln w="19050"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+    '</a:lnStyleLst>' +
+    '<a:effectStyleLst>' +
+    '<a:effectStyle><a:effectLst/></a:effectStyle>' +
+    '<a:effectStyle><a:effectLst/></a:effectStyle>' +
+    '<a:effectStyle><a:effectLst/></a:effectStyle>' +
+    '</a:effectStyleLst>' +
+    '<a:bgFillStyleLst>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+    '</a:bgFillStyleLst>' +
+    '</a:fmtScheme>' +
+    '</a:themeElements>' +
+    '</a:theme>';
+end;
+
+function TPowerPointPresentation.GenerateSlideXml(const Slide: IPowerPointSlide): string;
+begin
+  var SB := TStringBuilder.Create;
+  try
+    SB.Append(XmlDeclaration);
+    SB.Append('<p:sld' + SlideXmlnsAttrs + '>');
+    SB.Append('<p:cSld>');
+    SB.Append('<p:spTree>');
+    SB.Append('<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>');
+    SB.Append('<p:grpSpPr/>');
+
+    if Slide.Title <> '' then
+    begin
+      SB.Append('<p:sp>');
+      SB.Append('<p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>');
+      SB.Append('<p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>');
+      SB.Append('<p:spPr/>');
+      SB.Append('<p:txBody><a:bodyPr/><a:lstStyle/>');
+      SB.Append('<a:p><a:r><a:rPr lang="en-US" dirty="0"/><a:t>' + EscapeXml(Slide.Title) + '</a:t></a:r></a:p>');
+      SB.Append('</p:txBody>');
+      SB.Append('</p:sp>');
+    end;
+
+    if Slide.ParagraphCount > 0 then
+    begin
+      SB.Append('<p:sp>');
+      SB.Append('<p:nvSpPr><p:cNvPr id="3" name="Content 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>');
+      SB.Append('<p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>');
+      SB.Append('<p:spPr/>');
+      SB.Append('<p:txBody><a:bodyPr/><a:lstStyle/>');
+      for var I := 0 to Slide.ParagraphCount - 1 do
+        SB.Append(GenerateParagraphXml(Slide.Paragraphs[I]));
+      SB.Append('</p:txBody>');
+      SB.Append('</p:sp>');
+    end;
+
+    SB.Append('</p:spTree>');
+    SB.Append('</p:cSld>');
+    SB.Append('<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>');
+    SB.Append('</p:sld>');
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function TPowerPointPresentation.GenerateSlideRelsXml: string;
+begin
+  Result := XmlDeclaration +
+    '<Relationships xmlns="' + RelationshipsNs + '">' +
+    '<Relationship Id="rId1" Type="' + RelTypeSlideLayout + '" Target="../slideLayouts/slideLayout1.xml"/>' +
+    '</Relationships>';
+end;
+
+function TPowerPointPresentation.GenerateParagraphXml(const Paragraph: IPowerPointParagraph): string;
+begin
+  var SB := TStringBuilder.Create;
+  try
+    SB.Append('<a:p>');
+
+    // Bullets are always written explicitly (buChar or buNone), because PowerPoint
+    // applies its own bulleted defaults to body placeholder text otherwise.
+    var LevelAttr := '';
+    if Paragraph.IndentLevel > 0 then
+      LevelAttr := ' lvl="' + IntToStr(Paragraph.IndentLevel) + '"';
+    SB.Append('<a:pPr' + LevelAttr + '>');
+    if Paragraph.Bullet then
+      SB.Append('<a:buFont typeface="Arial"/><a:buChar char="' + BulletChar + '"/>')
+    else
+      SB.Append('<a:buNone/>');
+    SB.Append('</a:pPr>');
+
+    if Paragraph.RunCount = 0 then
+      SB.Append('<a:endParaRPr lang="en-US"/>')
+    else
+      for var I := 0 to Paragraph.RunCount - 1 do
+        SB.Append(GenerateRunXml(Paragraph.Runs[I]));
+
+    SB.Append('</a:p>');
+    Result := SB.ToString;
+  finally
+    SB.Free;
+  end;
+end;
+
+function TPowerPointPresentation.GenerateRunXml(const Run: IPowerPointRun): string;
+begin
+  var Attrs := ' lang="en-US"';
+  if Run.Bold then
+    Attrs := Attrs + ' b="1"';
+  if Run.Italic then
+    Attrs := Attrs + ' i="1"';
+  if Run.Underline then
+    Attrs := Attrs + ' u="sng"';
+  if Run.FontSize > 0 then
+    Attrs := Attrs + ' sz="' + IntToStr(Run.FontSize * 100) + '"';
+  Attrs := Attrs + ' dirty="0"';
+
+  var Children := '';
+  if Run.FontColor <> '' then
+    Children := Children + '<a:solidFill><a:srgbClr val="' + EscapeXml(Run.FontColor) + '"/></a:solidFill>';
+  if Run.FontName <> '' then
+    Children := Children + '<a:latin typeface="' + EscapeXml(Run.FontName) + '"/>';
+
+  var RPr := '';
+  if Children = '' then
+    RPr := '<a:rPr' + Attrs + '/>'
+  else
+    RPr := '<a:rPr' + Attrs + '>' + Children + '</a:rPr>';
+
+  Result := '<a:r>' + RPr + '<a:t>' + EscapeXml(Run.Text) + '</a:t></a:r>';
+end;
+
+function TPowerPointPresentation.EscapeXml(const Text: string): string;
+begin
+  Result := Text;
+  Result := StringReplace(Result, '&', '&amp;', [rfReplaceAll]);
+  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
+  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
+  Result := StringReplace(Result, '''', '&apos;', [rfReplaceAll]);
+end;
+
+procedure TPowerPointPresentation.LoadFromFile(const FileName: string);
+begin
+  FreeAndNil(FPackage);
+  FSlides.Clear;
+  FMetadata.Clear;
+
+  FPackage := TOXMLPackage.Create;
+  FPackage.Open(FileName);
+  ParsePackage;
+end;
+
+procedure TPowerPointPresentation.LoadFromStream(const Stream: TStream);
+begin
+  FreeAndNil(FPackage);
+  FSlides.Clear;
+  FMetadata.Clear;
+
+  FPackage := TOXMLPackage.Create;
+  FPackage.Open(Stream);
+  ParsePackage;
+end;
+
+procedure TPowerPointPresentation.ParsePackage;
+begin
+  var RootRelsXml := FPackage.GetPartContent(PartRootRels);
+  var RootRels := TRelationships.Create;
+  try
+    RootRels.LoadFromXml(RootRelsXml);
+    var PresentationPath := RootRels.GetTargetByType(RelTypeOfficeDocument);
+    if PresentationPath = '' then
+      Exit;
+    if PresentationPath.StartsWith('/') then
+      PresentationPath := PresentationPath.Substring(1);
+
+    const PresentationXml = FPackage.GetPartContent(PresentationPath);
+
+    const RelsPath = PartPresentationRels;
+    if not FPackage.PartExists(RelsPath) then
+      Exit;
+
+    var PresRels := TRelationships.Create;
+    try
+      PresRels.LoadFromXml(FPackage.GetPartContent(RelsPath));
+
+      // Slides are ordered by the sldIdLst in presentation.xml, not by part name.
+      const SlideIdMatches = TRegEx.Matches(PresentationXml, '<p:sldId\s[^>]*r:id="([^"]+)"', [roIgnoreCase]);
+      for var Match in SlideIdMatches do
+      begin
+        if Match.Groups.Count > 1 then
+        begin
+          const RelId = Match.Groups[1].Value;
+          var SlideTarget := PresRels.GetById(RelId).Target;
+          if SlideTarget.StartsWith('/') then
+            SlideTarget := SlideTarget.Substring(1)
+          else
+            SlideTarget := PartPptPrefix + SlideTarget;
+          ParseSlideXml(FPackage.GetPartContent(SlideTarget));
+        end;
+      end;
+    finally
+      PresRels.Free;
+    end;
+  finally
+    RootRels.Free;
+  end;
+
+  if FPackage.PartExists(PartCoreProps) then
+  begin
+    var MetaParser := TMetadataParser.Create;
+    try
+      FMetadata := MetaParser.Parse(FPackage.GetPartContent(PartCoreProps));
+    finally
+      MetaParser.Free;
+    end;
+  end;
+end;
+
+procedure TPowerPointPresentation.ParseSlideXml(const Xml: string);
+begin
+  const Slide = AddSlide;
+
+  const SpMatches = TRegEx.Matches(Xml, '<p:sp>(.*?)</p:sp>', [roIgnoreCase, roSingleLine]);
+  for var SpMatch in SpMatches do
+  begin
+    if SpMatch.Groups.Count > 1 then
+    begin
+      const SpXml = SpMatch.Groups[1].Value;
+      const IsTitle = TRegEx.IsMatch(SpXml, '<p:ph\s[^>]*type="(?:title|ctrTitle)"', [roIgnoreCase]);
+      if IsTitle then
+      begin
+        var Title := '';
+        const TextMatches = TRegEx.Matches(SpXml, '<a:t>([^<]*)</a:t>', [roIgnoreCase]);
+        for var TextMatch in TextMatches do
+          Title := Title + TextMatch.Groups[1].Value;
+        Slide.Title := Title;
+      end
+      else
+      begin
+        const ParagraphMatches = TRegEx.Matches(SpXml, '<a:p>(.*?)</a:p>', [roIgnoreCase, roSingleLine]);
+        for var ParagraphMatch in ParagraphMatches do
+          if ParagraphMatch.Groups.Count > 1 then
+            ParseParagraphXml(ParagraphMatch.Groups[1].Value, Slide);
+      end;
+    end;
+  end;
+end;
+
+procedure TPowerPointPresentation.ParseParagraphXml(const Xml: string; const Slide: IPowerPointSlide);
+begin
+  const Paragraph = Slide.AddParagraph;
+
+  Paragraph.Bullet := (Pos('<a:buChar', Xml) > 0) or (Pos('<a:buAutoNum', Xml) > 0);
+  const LevelMatch = TRegEx.Match(Xml, '<a:pPr[^>]*\slvl="(\d+)"', [roIgnoreCase]);
+  if LevelMatch.Success then
+    Paragraph.IndentLevel := StrToIntDef(LevelMatch.Groups[1].Value, 0);
+
+  const RunMatches = TRegEx.Matches(Xml, '<a:r>(.*?)</a:r>', [roIgnoreCase, roSingleLine]);
+  for var RunMatch in RunMatches do
+  begin
+    if RunMatch.Groups.Count > 1 then
+    begin
+      const RunXml = RunMatch.Groups[1].Value;
+      const TextMatch = TRegEx.Match(RunXml, '<a:t>([^<]*)</a:t>', [roIgnoreCase]);
+      if not TextMatch.Success then
+        Continue;
+
+      const Run = Paragraph.AddRun(TextMatch.Groups[1].Value);
+
+      const RPrMatch = TRegEx.Match(RunXml, '<a:rPr([^>]*?)(?:/>|>(.*?)</a:rPr>)', [roIgnoreCase, roSingleLine]);
+      if RPrMatch.Success then
+      begin
+        const RPrAttrs = RPrMatch.Groups[1].Value;
+        Run.Bold := TRegEx.IsMatch(RPrAttrs, '\bb="1"', [roIgnoreCase]);
+        Run.Italic := TRegEx.IsMatch(RPrAttrs, '\bi="1"', [roIgnoreCase]);
+        Run.Underline := TRegEx.IsMatch(RPrAttrs, '\bu="sng"', [roIgnoreCase]);
+
+        const SizeMatch = TRegEx.Match(RPrAttrs, '\bsz="(\d+)"', [roIgnoreCase]);
+        if SizeMatch.Success then
+          Run.FontSize := StrToIntDef(SizeMatch.Groups[1].Value, 0) div 100;
+
+        if RPrMatch.Groups.Count > 2 then
+        begin
+          const RPrChildren = RPrMatch.Groups[2].Value;
+          const ColorMatch = TRegEx.Match(RPrChildren, '<a:solidFill><a:srgbClr val="([0-9A-Fa-f]{6})"', [roIgnoreCase]);
+          if ColorMatch.Success then
+            Run.FontColor := ColorMatch.Groups[1].Value;
+          const FontMatch = TRegEx.Match(RPrChildren, '<a:latin typeface="([^"]*)"', [roIgnoreCase]);
+          if FontMatch.Success then
+            Run.FontName := FontMatch.Groups[1].Value;
+        end;
+      end;
+    end;
+  end;
+end;
+
+end.

--- a/Source/PowerPoint/Office4D.PowerPoint.pas
+++ b/Source/PowerPoint/Office4D.PowerPoint.pas
@@ -1,0 +1,106 @@
+unit Office4D.PowerPoint;
+
+interface
+
+uses
+  System.Classes,
+  Office4D.Metadata;
+
+type
+  IPowerPointRun = interface
+    ['{7E31A6C2-9B44-4D18-8A5F-2C6E90D1B3A7}']
+    function GetText: string;
+    procedure SetText(const Value: string);
+    function GetBold: Boolean;
+    procedure SetBold(const Value: Boolean);
+    function GetItalic: Boolean;
+    procedure SetItalic(const Value: Boolean);
+    function GetUnderline: Boolean;
+    procedure SetUnderline(const Value: Boolean);
+    function GetFontName: string;
+    procedure SetFontName(const Value: string);
+    function GetFontSize: Integer;
+    procedure SetFontSize(const Value: Integer);
+    function GetFontColor: string;
+    procedure SetFontColor(const Value: string);
+
+    property Text: string read GetText write SetText;
+    property Bold: Boolean read GetBold write SetBold;
+    property Italic: Boolean read GetItalic write SetItalic;
+    property Underline: Boolean read GetUnderline write SetUnderline;
+    property FontName: string read GetFontName write SetFontName;
+    property FontSize: Integer read GetFontSize write SetFontSize;
+    property FontColor: string read GetFontColor write SetFontColor;
+  end;
+
+  IPowerPointParagraph = interface
+    ['{7E31A6C2-9B44-4D18-8A5F-2C6E90D1B3A8}']
+    function GetText: string;
+    function GetRunCount: Integer;
+    function GetRun(Index: Integer): IPowerPointRun;
+    function AddRun(const Text: string): IPowerPointRun;
+    function GetBullet: Boolean;
+    procedure SetBullet(const Value: Boolean);
+    function GetIndentLevel: Integer;
+    procedure SetIndentLevel(const Value: Integer);
+
+    property Text: string read GetText;
+    property RunCount: Integer read GetRunCount;
+    property Runs[Index: Integer]: IPowerPointRun read GetRun;
+    property Bullet: Boolean read GetBullet write SetBullet;
+    property IndentLevel: Integer read GetIndentLevel write SetIndentLevel;
+  end;
+
+  IPowerPointSlide = interface
+    ['{7E31A6C2-9B44-4D18-8A5F-2C6E90D1B3A9}']
+    function GetTitle: string;
+    procedure SetTitle(const Value: string);
+    function GetText: string;
+    function GetParagraphCount: Integer;
+    function GetParagraph(Index: Integer): IPowerPointParagraph;
+    function AddParagraph: IPowerPointParagraph; overload;
+    function AddParagraph(const Text: string): IPowerPointParagraph; overload;
+
+    property Title: string read GetTitle write SetTitle;
+    property Text: string read GetText;
+    property ParagraphCount: Integer read GetParagraphCount;
+    property Paragraphs[Index: Integer]: IPowerPointParagraph read GetParagraph;
+  end;
+
+  IPowerPointPresentation = interface
+    ['{7E31A6C2-9B44-4D18-8A5F-2C6E90D1B3AA}']
+    procedure LoadFromFile(const FileName: string);
+    procedure LoadFromStream(const Stream: TStream);
+    procedure SaveToFile(const FileName: string);
+    procedure SaveToStream(const Stream: TStream);
+
+    function GetText: string;
+    function GetMetadata: TDocumentMetadata;
+
+    function GetSlideCount: Integer;
+    function GetSlide(Index: Integer): IPowerPointSlide;
+    function AddSlide: IPowerPointSlide; overload;
+    function AddSlide(const Title: string): IPowerPointSlide; overload;
+
+    property Text: string read GetText;
+    property Metadata: TDocumentMetadata read GetMetadata;
+    property SlideCount: Integer read GetSlideCount;
+    property Slides[Index: Integer]: IPowerPointSlide read GetSlide;
+  end;
+
+  TPowerPointPresentationFactory = class
+  public
+    class function CreatePresentation: IPowerPointPresentation;
+  end;
+
+implementation
+
+uses
+  Office4D.PowerPoint.Presentation;
+
+class function TPowerPointPresentationFactory.CreatePresentation: IPowerPointPresentation;
+begin
+  Result := TPowerPointPresentation.Create;
+end;
+
+end.

--- a/Source/Word/Office4D.Word.Document.pas
+++ b/Source/Word/Office4D.Word.Document.pas
@@ -137,7 +137,6 @@ type
     function GenerateDocumentRelsXml: string;
     function GenerateHeaderXml: string;
     function GenerateFooterXml: string;
-    function EscapeXml(const Text: string): string;
     function CollectHyperlinks: TList<string>;
     function GetHyperlinkId(const Url: string; const Hyperlinks: TList<string>): Integer;
     function HasListParagraphs: Boolean;
@@ -180,7 +179,8 @@ implementation
 
 uses
   Office4D.Errors,
-  Office4D.Types;
+  Office4D.Types,
+  Office4D.Xml;
 
 const
   XmlDeclaration = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -568,7 +568,7 @@ begin
           var TextMatch := TRegEx.Match(HyperlinkContent, TextPattern, [roIgnoreCase]);
           if TextMatch.Success and (TextMatch.Groups.Count > 1) then
           begin
-            var TextValue := TextMatch.Groups[1].Value;
+            var TextValue := TXml.Unescape(TextMatch.Groups[1].Value);
             if TextValue <> '' then
             begin
               var Run := Para.AddRun(TextValue);
@@ -599,7 +599,7 @@ begin
           var TextMatch := TRegEx.Match(RunXml, TextPattern, [roIgnoreCase]);
           if TextMatch.Success and (TextMatch.Groups.Count > 1) then
           begin
-            var TextValue := TextMatch.Groups[1].Value;
+            var TextValue := TXml.Unescape(TextMatch.Groups[1].Value);
             if TextValue <> '' then
               Para.AddRun(TextValue);
           end;
@@ -740,16 +740,6 @@ begin
       MetaParser.Free;
     end;
   end;
-end;
-
-function TWordDocument.EscapeXml(const Text: string): string;
-begin
-  Result := Text;
-  Result := StringReplace(Result, '&', '&amp;', [rfReplaceAll]);
-  Result := StringReplace(Result, '<', '&lt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '>', '&gt;', [rfReplaceAll]);
-  Result := StringReplace(Result, '"', '&quot;', [rfReplaceAll]);
-  Result := StringReplace(Result, '''', '&apos;', [rfReplaceAll]);
 end;
 
 function TWordDocument.CollectHyperlinks: TList<string>;
@@ -927,7 +917,7 @@ begin
       RelsContent := RelsContent +
         '<Relationship Id="rId' + IntToStr(NextId + I) + '" ' +
         'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" ' +
-        'Target="' + EscapeXml(Hyperlinks[I]) + '" TargetMode="External"/>';
+        'Target="' + TXml.Escape(Hyperlinks[I]) + '" TargetMode="External"/>';
     end;
     NextId := NextId + Hyperlinks.Count;
 
@@ -1062,7 +1052,7 @@ begin
           begin
             Body := Body + '<w:rPr>';
             if Run.FontName <> '' then
-              Body := Body + '<w:rFonts w:ascii="' + EscapeXml(Run.FontName) + '" w:hAnsi="' + EscapeXml(Run.FontName) + '"/>';
+              Body := Body + '<w:rFonts w:ascii="' + TXml.Escape(Run.FontName) + '" w:hAnsi="' + TXml.Escape(Run.FontName) + '"/>';
             if Run.Bold then
               Body := Body + '<w:b/>';
             if Run.Italic then
@@ -1072,10 +1062,10 @@ begin
             if Run.FontSize > 0 then
               Body := Body + '<w:sz w:val="' + IntToStr(Run.FontSize) + '"/>';
             if Run.FontColor <> '' then
-              Body := Body + '<w:color w:val="' + EscapeXml(Run.FontColor) + '"/>';
+              Body := Body + '<w:color w:val="' + TXml.Escape(Run.FontColor) + '"/>';
             Body := Body + '</w:rPr>';
           end;
-          Body := Body + '<w:t xml:space="preserve">' + EscapeXml(RunText) + '</w:t></w:r>';
+          Body := Body + '<w:t xml:space="preserve">' + TXml.Escape(RunText) + '</w:t></w:r>';
 
           if HasHyperlink then
             Body := Body + '</w:hyperlink>';
@@ -1148,7 +1138,7 @@ begin
             Body := Body + '</w:tcPr>';
           end;
 
-          Body := Body + '<w:p><w:r><w:t>' + EscapeXml(Cell.Text) + '</w:t></w:r></w:p>';
+          Body := Body + '<w:p><w:r><w:t>' + TXml.Escape(Cell.Text) + '</w:t></w:r></w:p>';
           Body := Body + '</w:tc>';
         end;
         Body := Body + '</w:tr>';
@@ -1495,7 +1485,7 @@ begin
   Result :=
     XmlDeclaration + sLineBreak +
     '<w:hdr xmlns:w="' + WordprocessingNs + '">' +
-    '<w:p><w:r><w:t>' + EscapeXml(FHeader.Text) + '</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:t>' + TXml.Escape(FHeader.Text) + '</w:t></w:r></w:p>' +
     '</w:hdr>';
 end;
 
@@ -1504,7 +1494,7 @@ begin
   Result :=
     XmlDeclaration + sLineBreak +
     '<w:ftr xmlns:w="' + WordprocessingNs + '">' +
-    '<w:p><w:r><w:t>' + EscapeXml(FFooter.Text) + '</w:t></w:r></w:p>' +
+    '<w:p><w:r><w:t>' + TXml.Escape(FFooter.Text) + '</w:t></w:r></w:p>' +
     '</w:ftr>';
 end;
 
@@ -1513,7 +1503,7 @@ begin
   var TextPattern := '<w:t[^>]*>([^<]*)</w:t>';
   var Match := TRegEx.Match(XmlContent, TextPattern, [roIgnoreCase]);
   if Match.Success and (Match.Groups.Count > 1) then
-    Target.Text := Match.Groups[1].Value;
+    Target.Text := TXml.Unescape(Match.Groups[1].Value);
 end;
 
 end.

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -34,6 +34,9 @@ type
     procedure RoundTrip_LoadModifySave_PreservesContent;
 
     [Test]
+    procedure RoundTrip_SpecialCharacters_ArePreserved;
+
+    [Test]
     procedure SaveToFile_ValidatesAsZip;
 
     [Test]
@@ -1126,6 +1129,19 @@ begin
   const Workbook2 = TExcelWorkbookFactory.Create;
   Workbook2.LoadFromFile(FTempFile);
   Assert.AreEqual(Double(TestValue), Double(Workbook2.Sheets[0].Cell['A1'].AsDateTime), 1E-8);
+end;
+
+procedure TExcelWriteTests.RoundTrip_SpecialCharacters_ArePreserved;
+begin
+  const Special = 'R&D <tag> "q" ''a'' 5>3';
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := Special;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual(Special, Workbook2.Sheets[0].Cell['A1'].AsString, 'Cell special characters should round-trip');
 end;
 
 initialization

--- a/Tests/Source/Office4D.Tests.PowerPoint.pas
+++ b/Tests/Source/Office4D.Tests.PowerPoint.pas
@@ -1,0 +1,434 @@
+unit Office4D.Tests.PowerPoint;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  System.Zip,
+  DUnitX.TestFramework,
+  Office4D.PowerPoint;
+
+type
+  [TestFixture]
+  TPowerPointWriteTests = class
+  private
+    FPresentation: IPowerPointPresentation;
+    FTempFile: string;
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure SaveToFile_NewPresentation_CreatesFile;
+
+    [Test]
+    procedure SaveToFile_ValidatesAsZip;
+
+    [Test]
+    procedure SaveToFile_ContainsRequiredParts;
+
+    [Test]
+    procedure SaveToFile_SlideCount_MatchesPresentationXml;
+
+    [Test]
+    procedure SaveToFile_TitleText_AppearsInSlideXml;
+
+    [Test]
+    procedure SaveToFile_BulletParagraph_WritesBuChar;
+
+    [Test]
+    procedure SaveToFile_PlainParagraph_WritesBuNone;
+
+    [Test]
+    procedure SaveToFile_BoldRun_WritesBoldAttribute;
+
+    [Test]
+    procedure SaveToFile_SpecialCharacters_AreEscaped;
+
+    [Test]
+    procedure SaveToStream_WritesToStream;
+  end;
+
+  [TestFixture]
+  TPowerPointRoundTripTests = class
+  private
+    FPresentation: IPowerPointPresentation;
+    FTempFile: string;
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure RoundTrip_SlideCount_IsPreserved;
+
+    [Test]
+    procedure RoundTrip_SlideOrder_IsPreserved;
+
+    [Test]
+    procedure RoundTrip_Title_IsPreserved;
+
+    [Test]
+    procedure RoundTrip_ParagraphTexts_ArePreserved;
+
+    [Test]
+    procedure RoundTrip_BulletAndIndentLevel_ArePreserved;
+
+    [Test]
+    procedure RoundTrip_RunFormatting_IsPreserved;
+
+    [Test]
+    procedure RoundTrip_GetText_ContainsTitleAndBody;
+
+    [Test]
+    procedure LoadFromStream_ReadsPresentation;
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  Office4D.Package;
+
+{ TPowerPointWriteTests }
+
+procedure TPowerPointWriteTests.Setup;
+begin
+  FPresentation := TPowerPointPresentationFactory.CreatePresentation;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'test_pptx_' + TGUID.NewGuid.ToString + '.pptx');
+end;
+
+procedure TPowerPointWriteTests.TearDown;
+begin
+  FPresentation := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_NewPresentation_CreatesFile;
+begin
+  FPresentation.AddSlide('Hello');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  Assert.IsTrue(TFile.Exists(FTempFile), 'File should be created');
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_ValidatesAsZip;
+begin
+  FPresentation.AddSlide('Hello');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(FTempFile, zmRead);
+    Assert.IsTrue(Zip.FileCount > 0, 'ZIP should contain files');
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_ContainsRequiredParts;
+begin
+  FPresentation.AddSlide('Hello');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    Assert.IsTrue(Package.PartExists('[Content_Types].xml'), 'Should contain content types');
+    Assert.IsTrue(Package.PartExists('_rels/.rels'), 'Should contain root rels');
+    Assert.IsTrue(Package.PartExists('ppt/presentation.xml'), 'Should contain presentation part');
+    Assert.IsTrue(Package.PartExists('ppt/slideMasters/slideMaster1.xml'), 'Should contain slide master');
+    Assert.IsTrue(Package.PartExists('ppt/slideLayouts/slideLayout1.xml'), 'Should contain slide layout');
+    Assert.IsTrue(Package.PartExists('ppt/theme/theme1.xml'), 'Should contain theme');
+    Assert.IsTrue(Package.PartExists('ppt/slides/slide1.xml'), 'Should contain slide part');
+    Assert.IsTrue(Package.PartExists('ppt/slides/_rels/slide1.xml.rels'), 'Should contain slide rels');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_SlideCount_MatchesPresentationXml;
+begin
+  FPresentation.AddSlide('One');
+  FPresentation.AddSlide('Two');
+  FPresentation.AddSlide('Three');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const PresentationXml = Package.GetPartContent('ppt/presentation.xml');
+    Assert.IsTrue(Pos('<p:sldId id="256"', PresentationXml) > 0, 'Should contain first slide id');
+    Assert.IsTrue(Pos('<p:sldId id="258"', PresentationXml) > 0, 'Should contain third slide id');
+    Assert.IsTrue(Package.PartExists('ppt/slides/slide3.xml'), 'Should contain third slide part');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_TitleText_AppearsInSlideXml;
+begin
+  FPresentation.AddSlide('Quarterly Report');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SlideXml = Package.GetPartContent('ppt/slides/slide1.xml');
+    Assert.IsTrue(Pos('type="title"', SlideXml) > 0, 'Should contain title placeholder');
+    Assert.IsTrue(Pos('<a:t>Quarterly Report</a:t>', SlideXml) > 0, 'Should contain title text');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_BulletParagraph_WritesBuChar;
+begin
+  const Slide = FPresentation.AddSlide('Agenda');
+  const Paragraph = Slide.AddParagraph('First point');
+  Paragraph.Bullet := True;
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SlideXml = Package.GetPartContent('ppt/slides/slide1.xml');
+    Assert.IsTrue(Pos('<a:buChar', SlideXml) > 0, 'Bullet paragraph should contain buChar');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_PlainParagraph_WritesBuNone;
+begin
+  const Slide = FPresentation.AddSlide('Notes');
+  Slide.AddParagraph('Plain text');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SlideXml = Package.GetPartContent('ppt/slides/slide1.xml');
+    Assert.IsTrue(Pos('<a:buNone/>', SlideXml) > 0, 'Plain paragraph should contain buNone');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_BoldRun_WritesBoldAttribute;
+begin
+  const Slide = FPresentation.AddSlide('Formatting');
+  const Paragraph = Slide.AddParagraph;
+  const Run = Paragraph.AddRun('Important');
+  Run.Bold := True;
+  Run.FontSize := 24;
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SlideXml = Package.GetPartContent('ppt/slides/slide1.xml');
+    Assert.IsTrue(Pos('b="1"', SlideXml) > 0, 'Bold run should have b attribute');
+    Assert.IsTrue(Pos('sz="2400"', SlideXml) > 0, 'Font size should be written in hundredths of a point');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToFile_SpecialCharacters_AreEscaped;
+begin
+  FPresentation.AddSlide('Q&A <Session>');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SlideXml = Package.GetPartContent('ppt/slides/slide1.xml');
+    Assert.IsTrue(Pos('Q&amp;A &lt;Session&gt;', SlideXml) > 0, 'Special characters should be XML-escaped');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TPowerPointWriteTests.SaveToStream_WritesToStream;
+begin
+  FPresentation.AddSlide('Stream Test');
+
+  var Stream := TMemoryStream.Create;
+  try
+    FPresentation.SaveToStream(Stream);
+    Assert.IsTrue(Stream.Size > 0, 'Stream should contain data');
+  finally
+    Stream.Free;
+  end;
+end;
+
+{ TPowerPointRoundTripTests }
+
+procedure TPowerPointRoundTripTests.Setup;
+begin
+  FPresentation := TPowerPointPresentationFactory.CreatePresentation;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'test_pptx_' + TGUID.NewGuid.ToString + '.pptx');
+end;
+
+procedure TPowerPointRoundTripTests.TearDown;
+begin
+  FPresentation := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_SlideCount_IsPreserved;
+begin
+  FPresentation.AddSlide('One');
+  FPresentation.AddSlide('Two');
+  FPresentation.AddSlide('Three');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  Assert.AreEqual(3, Presentation2.SlideCount);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_SlideOrder_IsPreserved;
+begin
+  FPresentation.AddSlide('First');
+  FPresentation.AddSlide('Second');
+  FPresentation.AddSlide('Third');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  Assert.AreEqual('First', Presentation2.Slides[0].Title);
+  Assert.AreEqual('Second', Presentation2.Slides[1].Title);
+  Assert.AreEqual('Third', Presentation2.Slides[2].Title);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_Title_IsPreserved;
+begin
+  FPresentation.AddSlide('Quarterly Report');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  Assert.AreEqual('Quarterly Report', Presentation2.Slides[0].Title);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_ParagraphTexts_ArePreserved;
+begin
+  const Slide = FPresentation.AddSlide('Agenda');
+  Slide.AddParagraph('First item');
+  Slide.AddParagraph('Second item');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  const Slide2 = Presentation2.Slides[0];
+  Assert.AreEqual(2, Slide2.ParagraphCount);
+  Assert.AreEqual('First item', Slide2.Paragraphs[0].Text);
+  Assert.AreEqual('Second item', Slide2.Paragraphs[1].Text);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_BulletAndIndentLevel_ArePreserved;
+begin
+  const Slide = FPresentation.AddSlide('Agenda');
+  const Bullet = Slide.AddParagraph('Bullet point');
+  Bullet.Bullet := True;
+  const SubBullet = Slide.AddParagraph('Sub point');
+  SubBullet.Bullet := True;
+  SubBullet.IndentLevel := 1;
+  Slide.AddParagraph('Plain closing line');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  const Slide2 = Presentation2.Slides[0];
+  Assert.IsTrue(Slide2.Paragraphs[0].Bullet, 'First paragraph should be a bullet');
+  Assert.AreEqual(0, Slide2.Paragraphs[0].IndentLevel);
+  Assert.IsTrue(Slide2.Paragraphs[1].Bullet, 'Second paragraph should be a bullet');
+  Assert.AreEqual(1, Slide2.Paragraphs[1].IndentLevel);
+  Assert.IsFalse(Slide2.Paragraphs[2].Bullet, 'Third paragraph should not be a bullet');
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_RunFormatting_IsPreserved;
+begin
+  const Slide = FPresentation.AddSlide('Formatting');
+  const Paragraph = Slide.AddParagraph;
+  const Run = Paragraph.AddRun('Styled text');
+  Run.Bold := True;
+  Run.Italic := True;
+  Run.Underline := True;
+  Run.FontSize := 28;
+  Run.FontName := 'Arial';
+  Run.FontColor := 'FF0000';
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  const Run2 = Presentation2.Slides[0].Paragraphs[0].Runs[0];
+  Assert.AreEqual('Styled text', Run2.Text);
+  Assert.IsTrue(Run2.Bold, 'Bold should be preserved');
+  Assert.IsTrue(Run2.Italic, 'Italic should be preserved');
+  Assert.IsTrue(Run2.Underline, 'Underline should be preserved');
+  Assert.AreEqual(28, Run2.FontSize);
+  Assert.AreEqual('Arial', Run2.FontName);
+  Assert.AreEqual('FF0000', Run2.FontColor);
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_GetText_ContainsTitleAndBody;
+begin
+  const Slide = FPresentation.AddSlide('My Title');
+  Slide.AddParagraph('Body line');
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  Assert.IsTrue(Pos('My Title', Presentation2.Text) > 0, 'Text should contain the title');
+  Assert.IsTrue(Pos('Body line', Presentation2.Text) > 0, 'Text should contain the body text');
+end;
+
+procedure TPowerPointRoundTripTests.LoadFromStream_ReadsPresentation;
+begin
+  FPresentation.AddSlide('Stream Round Trip');
+  FPresentation.SaveToFile(FTempFile);
+
+  var Stream := TFileStream.Create(FTempFile, fmOpenRead or fmShareDenyWrite);
+  try
+    const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+    Presentation2.LoadFromStream(Stream);
+    Assert.AreEqual(1, Presentation2.SlideCount);
+    Assert.AreEqual('Stream Round Trip', Presentation2.Slides[0].Title);
+  finally
+    Stream.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TPowerPointWriteTests);
+  TDUnitX.RegisterTestFixture(TPowerPointRoundTripTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.PowerPoint.pas
+++ b/Tests/Source/Office4D.Tests.PowerPoint.pas
@@ -88,6 +88,9 @@ type
 
     [Test]
     procedure LoadFromStream_ReadsPresentation;
+
+    [Test]
+    procedure RoundTrip_SpecialCharacters_ArePreserved;
   end;
 
 implementation
@@ -425,6 +428,21 @@ begin
   finally
     Stream.Free;
   end;
+end;
+
+procedure TPowerPointRoundTripTests.RoundTrip_SpecialCharacters_ArePreserved;
+begin
+  const Special = 'Q&A <tag> "quote" ''apos'' 100% > 50%';
+  const Slide = FPresentation.AddSlide(Special);
+  Slide.AddParagraph(Special);
+
+  FPresentation.SaveToFile(FTempFile);
+
+  const Presentation2 = TPowerPointPresentationFactory.CreatePresentation;
+  Presentation2.LoadFromFile(FTempFile);
+  const Slide2 = Presentation2.Slides[0];
+  Assert.AreEqual(Special, Slide2.Title, 'Title special characters should round-trip');
+  Assert.AreEqual(Special, Slide2.Paragraphs[0].Text, 'Paragraph special characters should round-trip');
 end;
 
 initialization

--- a/Tests/Source/Office4D.Tests.Word.Write.pas
+++ b/Tests/Source/Office4D.Tests.Word.Write.pas
@@ -34,6 +34,9 @@ type
     procedure RoundTrip_LoadModifySave_PreservesContent;
 
     [Test]
+    procedure RoundTrip_SpecialCharacters_ArePreserved;
+
+    [Test]
     procedure SaveToFile_ValidatesAsZip;
 
     [Test]
@@ -917,6 +920,18 @@ begin
   finally
     Package.Free;
   end;
+end;
+
+procedure TWordWriteTests.RoundTrip_SpecialCharacters_ArePreserved;
+begin
+  const Special = 'R&D <tag> "q" ''a'' 5>3';
+  FDoc.AddParagraph.AddRun(Special);
+
+  FDoc.SaveToFile(FTempFile);
+
+  var Doc2 := TWordDocumentFactory.CreateDocument;
+  Doc2.LoadFromFile(FTempFile);
+  Assert.AreEqual(Special, Doc2.Paragraphs[0].Runs[0].Text, 'Run special characters should round-trip');
 end;
 
 initialization

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -13,6 +13,7 @@ uses
   Office4D.Errors in '..\..\Source\Core\Office4D.Errors.pas',
   Office4D.Package in '..\..\Source\Core\Office4D.Package.pas',
   Office4D.Relationships in '..\..\Source\Core\Office4D.Relationships.pas',
+  Office4D.Xml in '..\..\Source\Core\Office4D.Xml.pas',
   Office4D.Metadata in '..\..\Source\Common\Office4D.Metadata.pas',
   Office4D.Word in '..\..\Source\Word\Office4D.Word.pas',
   Office4D.Word.Document in '..\..\Source\Word\Office4D.Word.Document.pas',

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -18,6 +18,8 @@ uses
   Office4D.Word.Document in '..\..\Source\Word\Office4D.Word.Document.pas',
   Office4D.Excel in '..\..\Source\Excel\Office4D.Excel.pas',
   Office4D.Excel.Workbook in '..\..\Source\Excel\Office4D.Excel.Workbook.pas',
+  Office4D.PowerPoint in '..\..\Source\PowerPoint\Office4D.PowerPoint.pas',
+  Office4D.PowerPoint.Presentation in '..\..\Source\PowerPoint\Office4D.PowerPoint.Presentation.pas',
   Office4D.Tests.Samples in 'Office4D.Tests.Samples.pas',
   Office4D.Tests.Package in 'Office4D.Tests.Package.pas',
   Office4D.Tests.Relationships in 'Office4D.Tests.Relationships.pas',
@@ -25,7 +27,8 @@ uses
   Office4D.Tests.Word in 'Office4D.Tests.Word.pas',
   Office4D.Tests.Word.Write in 'Office4D.Tests.Word.Write.pas',
   Office4D.Tests.Excel in 'Office4D.Tests.Excel.pas',
-  Office4D.Tests.Excel.Write in 'Office4D.Tests.Excel.Write.pas';
+  Office4D.Tests.Excel.Write in 'Office4D.Tests.Excel.Write.pas',
+  Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Source/Office4D.Tests.dproj
+++ b/Tests/Source/Office4D.Tests.dproj
@@ -152,6 +152,8 @@
         <DCCReference Include="..\..\Source\Word\Office4D.Word.Document.pas"/>
         <DCCReference Include="..\..\Source\Excel\Office4D.Excel.pas"/>
         <DCCReference Include="..\..\Source\Excel\Office4D.Excel.Workbook.pas"/>
+        <DCCReference Include="..\..\Source\PowerPoint\Office4D.PowerPoint.pas"/>
+        <DCCReference Include="..\..\Source\PowerPoint\Office4D.PowerPoint.Presentation.pas"/>
         <DCCReference Include="Office4D.Tests.Samples.pas"/>
         <DCCReference Include="Office4D.Tests.Package.pas"/>
         <DCCReference Include="Office4D.Tests.Relationships.pas"/>
@@ -160,6 +162,7 @@
         <DCCReference Include="Office4D.Tests.Word.Write.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.Write.pas"/>
+        <DCCReference Include="Office4D.Tests.PowerPoint.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
First phase of PowerPoint (.pptx) support, as discussed in #8.

## Scope

**Writing:** create presentations with multiple slides — slide titles, body paragraphs, bullet lists with indent levels, and run formatting (bold, italic, underline, font name/size/color). The required PresentationML boilerplate (slide master, slide layout, theme) is generated automatically.

**Reading:** slide count, titles, body paragraphs with formatting, and plain-text extraction (`Presentation.Text`), plus core metadata. Slide order follows `sldIdLst`, not part names.

**Not in scope (yet):** images, free shape positioning, speaker notes, and lossless round-trip of presentations created by PowerPoint itself (loading extracts the text model; saving regenerates all parts).

## API

Mirrors the existing Word/Excel design — interface-based with a factory:

```pascal
var Presentation := TPowerPointPresentationFactory.CreatePresentation;
var Slide := Presentation.AddSlide('Quarterly Report');
var Bullet := Slide.AddParagraph('Revenue up 12%');
Bullet.Bullet := True;
Presentation.SaveToFile('report.pptx');
```

New units `Office4D.PowerPoint` (interfaces) and `Office4D.PowerPoint.Presentation` (implementation); `Core`/`Common` are reused as-is.

## Tests

18 new tests in `Office4D.Tests.PowerPoint` (write assertions on the generated XML parts + full round-trip coverage). Full suite: 202 tests, 0 failures, 0 leaks.

---

## Update: centralised XML escaping (DRY)

Review of this PR surfaced that `EscapeXml` was duplicated in the Word, Excel and PowerPoint modules, and that the read side did not unescape entities, so text containing `&`, `<`, `>`, `"` or `'` did not round-trip (Excel did not even escape shared-string cell text on write). This adds a shared `Office4D.Xml` (`TXml.Escape`/`TXml.Unescape`), routes all three modules through it, and fixes the read-side unescaping. Round-trip tests with special characters were added for Word, Excel and PowerPoint. Full suite: 205 tests, 0 failures, 0 leaks.