### PR TITLE
Add binary attributes for document file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,5 +13,11 @@
 *.ico binary
 *.png binary
 *.gif binary
+*.docx binary
+*.xlsx binary
+*.pptx binary
+*.doc binary
+*.xls binary
+*.ppt binary
 
 *.dspec filter=insert-hash


### PR DESCRIPTION
Git should threat Office document files as binary - not touching and corrupting them