### PR TITLE
Enh borderstyles

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -33,8 +33,8 @@ type
     FFontSize: Double;
     FBackgroundColor: Cardinal;
     FNumberFormat: string;
-    FBorderStyle: TExcelBorderStyle;
-    FBorderColor: Cardinal;
+    FBorderStyle: array[TExcelBorderSide] of TExcelBorderStyle;
+    FBorderColor: array[TExcelBorderSide] of Cardinal;
     FHAlign: TExcelHAlign;
     FVAlign: TExcelVAlign;
     FWrapText: Boolean;
@@ -65,10 +65,10 @@ type
     procedure SetBackgroundColor(const Value: Cardinal);
     function GetNumberFormat: string;
     procedure SetNumberFormat(const Value: string);
-    function GetBorderStyle: TExcelBorderStyle;
-    procedure SetBorderStyle(const Value: TExcelBorderStyle);
-    function GetBorderColor: Cardinal;
-    procedure SetBorderColor(const Value: Cardinal);
+    function GetBorderStyle(ASides: TExcelBorderSides): TExcelBorderStyle;
+    procedure SetBorderStyle(ASides: TExcelBorderSides; const Value: TExcelBorderStyle);
+    function GetBorderColor(ASides: TExcelBorderSides): Cardinal;
+    procedure SetBorderColor(ASides: TExcelBorderSides; const Value: Cardinal);
     function GetHAlign: TExcelHAlign;
     procedure SetHAlign(const Value: TExcelHAlign);
     function GetVAlign: TExcelVAlign;
@@ -133,12 +133,18 @@ type
     FStyleFontName: TList<string>;
     FStyleFontSize: TList<Double>;
     FStyleColors: TList<Cardinal>;
-    FStyleBorderStyle: TList<TExcelBorderStyle>;
-    FStyleBorderColor: TList<Cardinal>;
+    FStyleFontColor: TList<Cardinal>;
+    FStyleBorderTopStyle: TList<TExcelBorderStyle>;
+    FStyleBorderTopColor: TList<Cardinal>;
+    FStyleBorderRightStyle: TList<TExcelBorderStyle>;
+    FStyleBorderRightColor: TList<Cardinal>;
+    FStyleBorderBottomStyle: TList<TExcelBorderStyle>;
+    FStyleBorderBottomColor: TList<Cardinal>;
+    FStyleBorderLeftStyle: TList<TExcelBorderStyle>;
+    FStyleBorderLeftColor: TList<Cardinal>;
     FStyleHAlign: TList<TExcelHAlign>;
     FStyleVAlign: TList<TExcelVAlign>;
     FStyleWrapText: TList<Boolean>;
-    FStyleFontColor: TList<Cardinal>;
 
     procedure ParseWorkbook(const Xml: string);
     procedure ParseSharedStrings(const Xml: string);
@@ -200,7 +206,6 @@ const
     $003366, $339966, $003300, $333300, $993300, $993366, $333399, $333333   // 56-63
   );
 
-  ExcelDateOffset = 25569;
   XmlDeclaration = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
   RelationshipsNs = 'http://schemas.openxmlformats.org/package/2006/relationships';
   ContentTypesNs = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -256,7 +261,7 @@ begin
   if FCellType = TCellType.DateTime then
     Result := FDateTimeValue
   else if FCellType = TCellType.Number then
-    Result := FFloatValue - ExcelDateOffset
+    Result := FFloatValue
   else
     Result := 0;
 end;
@@ -264,7 +269,7 @@ end;
 procedure TExcelCell.SetAsDateTime(const Value: TDateTime);
 begin
   FDateTimeValue := Value;
-  FFloatValue := Value + ExcelDateOffset;
+  FFloatValue := Value;
   FCellType := TCellType.DateTime;
 end;
 
@@ -370,24 +375,34 @@ begin
   FFontSize := Value;
 end;
 
-function TExcelCell.GetBorderStyle: TExcelBorderStyle;
+function TExcelCell.GetBorderStyle(ASides: TExcelBorderSides): TExcelBorderStyle;
 begin
-  Result := FBorderStyle;
+  Result := TExcelBorderStyle.None;
+  for var Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+    if Side in ASides then
+      Exit(FBorderStyle[Side]); // returns the first matching side in Top/Right/Bottom/Left order
 end;
 
-procedure TExcelCell.SetBorderStyle(const Value: TExcelBorderStyle);
+procedure TExcelCell.SetBorderStyle(ASides: TExcelBorderSides; const Value: TExcelBorderStyle);
 begin
-  FBorderStyle := Value;
+  for var Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+    if Side in ASides then
+      FBorderStyle[Side] := Value;
 end;
 
-function TExcelCell.GetBorderColor: Cardinal;
+function TExcelCell.GetBorderColor(ASides: TExcelBorderSides): Cardinal;
 begin
-  Result := FBorderColor;
+  Result := 0;
+  for var Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+    if Side in ASides then
+      Exit(FBorderColor[Side]); // returns the first matching side in Top/Right/Bottom/Left order
 end;
 
-procedure TExcelCell.SetBorderColor(const Value: Cardinal);
+procedure TExcelCell.SetBorderColor(ASides: TExcelBorderSides; const Value: Cardinal);
 begin
-  FBorderColor := Value;
+  for var Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+    if Side in ASides then
+      FBorderColor[Side] := Value;
 end;
 
 function TExcelCell.GetHAlign: TExcelHAlign;
@@ -425,7 +440,13 @@ begin
   const HasFont = (FBold) or (FItalic) or (FUnderline) or (FFontName <> '') or (FFontSize <> 0) or (FFontColor <> 0);
   const HasFill = (FBackgroundColor <> 0);
   const HasFormat = (FCellType = TCellType.DateTime);
-  const HasBorder = (FBorderStyle <> TExcelBorderStyle.None);
+  var HasBorder := False;
+  for var Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+    if FBorderStyle[Side] <> TExcelBorderStyle.None then
+    begin
+      HasBorder := True;
+      Break;
+    end;
   const HasAlign = (FHAlign <> TExcelHAlign.None) or (FVAlign <> TExcelVAlign.None) or (FWrapText);
   Result := (HasFont) or (HasFill) or (HasFormat) or (HasBorder) or (HasAlign);
 end;
@@ -553,22 +574,34 @@ begin
   FStyleFontName := TList<string>.Create;
   FStyleFontSize := TList<Double>.Create;
   FStyleColors := TList<Cardinal>.Create;
-  FStyleBorderStyle := TList<TExcelBorderStyle>.Create;
-  FStyleBorderColor := TList<Cardinal>.Create;
+  FStyleFontColor := TList<Cardinal>.Create;
+  FStyleBorderTopStyle := TList<TExcelBorderStyle>.Create;
+  FStyleBorderTopColor := TList<Cardinal>.Create;
+  FStyleBorderRightStyle := TList<TExcelBorderStyle>.Create;
+  FStyleBorderRightColor := TList<Cardinal>.Create;
+  FStyleBorderBottomStyle := TList<TExcelBorderStyle>.Create;
+  FStyleBorderBottomColor := TList<Cardinal>.Create;
+  FStyleBorderLeftStyle := TList<TExcelBorderStyle>.Create;
+  FStyleBorderLeftColor := TList<Cardinal>.Create;
   FStyleHAlign := TList<TExcelHAlign>.Create;
   FStyleVAlign := TList<TExcelVAlign>.Create;
   FStyleWrapText := TList<Boolean>.Create;
-  FStyleFontColor := TList<Cardinal>.Create;
 end;
 
 destructor TExcelWorkbook.Destroy;
 begin
-  FStyleFontColor.Free;
   FStyleWrapText.Free;
   FStyleVAlign.Free;
   FStyleHAlign.Free;
-  FStyleBorderColor.Free;
-  FStyleBorderStyle.Free;
+  FStyleBorderLeftColor.Free;
+  FStyleBorderLeftStyle.Free;
+  FStyleBorderBottomColor.Free;
+  FStyleBorderBottomStyle.Free;
+  FStyleBorderRightColor.Free;
+  FStyleBorderRightStyle.Free;
+  FStyleBorderTopColor.Free;
+  FStyleBorderTopStyle.Free;
+  FStyleFontColor.Free;
   FStyleColors.Free;
   FStyleFontSize.Free;
   FStyleFontName.Free;
@@ -1060,7 +1093,7 @@ begin
       DateFlag := 2
     else
       DateFlag := 1;
-  Result := Format('%d|%d|%d|%s|%d|%d|%s|%s|%d|%d|%d|%d|%d|%d', [
+  Result := Format('%d|%d|%d|%s|%d|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d', [
     Ord(Cell.FBold),
     Cell.FBackgroundColor,
     DateFlag,
@@ -1069,8 +1102,14 @@ begin
     Ord(Cell.FUnderline),
     Cell.FFontName,
     FontSizeStr,
-    Ord(Cell.FBorderStyle),
-    Cell.FBorderColor,
+    Ord(Cell.FBorderStyle[TExcelBorderSide.Top]),             // 8
+    Cell.FBorderColor[TExcelBorderSide.Top],                  // 9
+    Ord(Cell.FBorderStyle[TExcelBorderSide.Right]),           // 10
+    Cell.FBorderColor[TExcelBorderSide.Right],                // 11
+    Ord(Cell.FBorderStyle[TExcelBorderSide.Bottom]),          // 12
+    Cell.FBorderColor[TExcelBorderSide.Bottom],               // 13
+    Ord(Cell.FBorderStyle[TExcelBorderSide.Left]),            // 14
+    Cell.FBorderColor[TExcelBorderSide.Left],                 // 15
     Ord(Cell.FHAlign),
     Ord(Cell.FVAlign),
     Ord(Cell.FWrapText),
@@ -1081,8 +1120,23 @@ end;
 function TExcelWorkbook.BuildStyleMap: TDictionary<string, Integer>;
 begin
   Result := TDictionary<string, Integer>.Create;
-  Result.Add('0|0|0||0|0|||0|0|0|0|0|0', 0);
-  Result.Add('0|0|1||0|0|||0|0|0|0|0|0', 1);
+
+  // Built from real TExcelCell instances via GetStyleKey rather than hand-typed literal
+  // strings, so these can never drift out of sync with GetStyleKey's field list/order.
+  var PlainCell := TExcelCell.Create;
+  try
+    Result.Add(GetStyleKey(PlainCell), 0);
+  finally
+    PlainCell.Free;
+  end;
+
+  var DateCell := TExcelCell.Create;
+  try
+    DateCell.SetAsDateTime(Trunc(Now)); // Trunc -> Frac = 0 -> DateFlag = 1 (date-only, numFmtId 14)
+    Result.Add(GetStyleKey(DateCell), 1);
+  finally
+    DateCell.Free;
+  end;
 
   var NextIndex := 2;
   for var Sheet in FSheets do
@@ -1149,6 +1203,17 @@ function TExcelWorkbook.GenerateStyles(const StyleMap: TDictionary<string, Integ
     end;
   end;
 
+  function SideElement(const Tag: string; AStyle: TExcelBorderStyle; AColor: Cardinal): string;
+  begin
+    if AStyle = TExcelBorderStyle.None then
+      Exit('<' + Tag + '/>');
+    var ColorAttr := '';
+    if AColor <> 0 then
+      ColorAttr := '<color rgb="FF' + IntToHex(AColor, 6) + '"/>'
+    else
+      ColorAttr := '<color auto="1"/>';
+    Result := '<' + Tag + ' style="' + BorderStyleToString(AStyle) + '">' + ColorAttr + '</' + Tag + '>';
+  end;
 begin
   var Colors := TList<Cardinal>.Create;
   var NumFormats := TList<string>.Create;
@@ -1174,8 +1239,12 @@ begin
       if (FontKey <> '0|0|0|||0') and (not FontKeys.Contains(FontKey)) then
         FontKeys.Add(FontKey);
 
-      const BorderKey = Format('%d|%d', [Ord(Cell.FBorderStyle), Cell.FBorderColor]);
-      if (BorderKey <> '0|0') and (not BorderKeys.Contains(BorderKey)) then
+      const BorderKey = Format('%d|%d|%d|%d|%d|%d|%d|%d', [
+        Ord(Cell.FBorderStyle[TExcelBorderSide.Top]), Cell.FBorderColor[TExcelBorderSide.Top],
+        Ord(Cell.FBorderStyle[TExcelBorderSide.Right]), Cell.FBorderColor[TExcelBorderSide.Right],
+        Ord(Cell.FBorderStyle[TExcelBorderSide.Bottom]), Cell.FBorderColor[TExcelBorderSide.Bottom],
+        Ord(Cell.FBorderStyle[TExcelBorderSide.Left]), Cell.FBorderColor[TExcelBorderSide.Left]]);
+      if (BorderKey <> '0|0|0|0|0|0|0|0') and (not BorderKeys.Contains(BorderKey)) then
         BorderKeys.Add(BorderKey);
     end;
   end;
@@ -1239,19 +1308,20 @@ begin
     for var BorderKey in BorderKeys do
     begin
       const BorderParts = BorderKey.Split(['|']);
-      const BorderStyle = TExcelBorderStyle(StrToIntDef(BorderParts[0], 0));
-      const BorderColor = StrToIntDef(BorderParts[1], 0);
-      const StyleStr = BorderStyleToString(BorderStyle);
-      var ColorAttr := '';
-      if BorderColor <> 0 then
-        ColorAttr := '<color rgb="FF' + IntToHex(BorderColor, 6) + '"/>'
-      else
-        ColorAttr := '<color auto="1"/>';
+      const TopStyle    = TExcelBorderStyle(StrToIntDef(BorderParts[0], 0));
+      const TopColor    = StrToIntDef(BorderParts[1], 0);
+      const RightStyle  = TExcelBorderStyle(StrToIntDef(BorderParts[2], 0));
+      const RightColor  = StrToIntDef(BorderParts[3], 0);
+      const BottomStyle = TExcelBorderStyle(StrToIntDef(BorderParts[4], 0));
+      const BottomColor = StrToIntDef(BorderParts[5], 0);
+      const LeftStyle   = TExcelBorderStyle(StrToIntDef(BorderParts[6], 0));
+      const LeftColor   = StrToIntDef(BorderParts[7], 0);
+
       SB.Append('<border>');
-      SB.Append('<left style="' + StyleStr + '">' + ColorAttr + '</left>');
-      SB.Append('<right style="' + StyleStr + '">' + ColorAttr + '</right>');
-      SB.Append('<top style="' + StyleStr + '">' + ColorAttr + '</top>');
-      SB.Append('<bottom style="' + StyleStr + '">' + ColorAttr + '</bottom>');
+      SB.Append(SideElement('left', LeftStyle, LeftColor));
+      SB.Append(SideElement('right', RightStyle, RightColor));
+      SB.Append(SideElement('top', TopStyle, TopColor));
+      SB.Append(SideElement('bottom', BottomStyle, BottomColor));
       SB.Append('</border>');
     end;
     SB.Append('</borders>');
@@ -1282,13 +1352,21 @@ begin
         const IsUnderline = Parts[5] = '1';
         const CellFontName = Parts[6];
         const CellFontSize = Parts[7];
-        const CellBorderStyle = TExcelBorderStyle(StrToIntDef(Parts[8], 0));
-        const CellBorderColor = StrToIntDef(Parts[9], 0);
-        const CellHAlign = TExcelHAlign(StrToIntDef(Parts[10], 0));
-        const CellVAlign = TExcelVAlign(StrToIntDef(Parts[11], 0));
-        const CellWrapText = Parts[12] = '1';
-        const CellFontColor = StrToIntDef(Parts[13], 0);
+        const CellBorderTopStyle    = TExcelBorderStyle(StrToIntDef(Parts[8], 0));
+        const CellBorderTopColor    = StrToIntDef(Parts[9], 0);
+        const CellBorderRightStyle  = TExcelBorderStyle(StrToIntDef(Parts[10], 0));
+        const CellBorderRightColor  = StrToIntDef(Parts[11], 0);
+        const CellBorderBottomStyle = TExcelBorderStyle(StrToIntDef(Parts[12], 0));
+        const CellBorderBottomColor = StrToIntDef(Parts[13], 0);
+        const CellBorderLeftStyle   = TExcelBorderStyle(StrToIntDef(Parts[14], 0));
+        const CellBorderLeftColor   = StrToIntDef(Parts[15], 0);
+        const CellHAlign = TExcelHAlign(StrToIntDef(Parts[16], 0));
+        const CellVAlign = TExcelVAlign(StrToIntDef(Parts[17], 0));
+        const CellWrapText = Parts[18] = '1';
+        const CellFontColor = StrToIntDef(Parts[19], 0);
 
+        // Must match the FontKeys population format in the collection loop above,
+        // field-for-field — this 5-vs-6-field mismatch was the original FontColor bug.
         const FontKey = Format('%d|%d|%d|%s|%s|%d', [
           Ord(IsBold), Ord(IsItalic), Ord(IsUnderline), CellFontName, CellFontSize, CellFontColor]);
         var FontId := 0;
@@ -1299,9 +1377,13 @@ begin
         if BgColor <> 0 then
           FillId := 2 + Colors.IndexOf(BgColor);
 
-        const BorderKey = Format('%d|%d', [Ord(CellBorderStyle), CellBorderColor]);
+        const BorderKey = Format('%d|%d|%d|%d|%d|%d|%d|%d', [
+          Ord(CellBorderTopStyle), CellBorderTopColor,
+          Ord(CellBorderRightStyle), CellBorderRightColor,
+          Ord(CellBorderBottomStyle), CellBorderBottomColor,
+          Ord(CellBorderLeftStyle), CellBorderLeftColor]);
         var BorderId := 0;
-        if BorderKey <> '0|0' then
+        if BorderKey <> '0|0|0|0|0|0|0|0' then
           BorderId := 1 + BorderKeys.IndexOf(BorderKey);
 
         // A user-supplied NumberFormat overrides the default date format, so custom
@@ -1416,6 +1498,22 @@ procedure TExcelWorkbook.ParseStyles(const Xml: string);
     else Result := TExcelVAlign.None;
   end;
 
+  procedure ParseSide(const BorderXml, Tag: string; out AStyle: TExcelBorderStyle; out AColor: Cardinal);
+  begin
+    const SideMatch = TRegEx.Match(BorderXml, '<' + Tag + '\s+style="([^"]*)"', [roIgnoreCase]);
+    if SideMatch.Success then
+      AStyle := StringToBorderStyle(SideMatch.Groups[1].Value)
+    else
+      AStyle := TExcelBorderStyle.None;
+
+    const ColorMatch = TRegEx.Match(BorderXml,
+      '<' + Tag + '[^>]*>.*?<color\s+rgb="FF([0-9A-Fa-f]{6})"', [roIgnoreCase, roSingleLine]);
+    if ColorMatch.Success then
+      AColor := StrToInt64Def('$' + ColorMatch.Groups[1].Value, 0)
+    else
+      AColor := 0;
+  end;
+
 begin
   FStyleBold.Clear;
   FStyleItalic.Clear;
@@ -1423,12 +1521,18 @@ begin
   FStyleFontName.Clear;
   FStyleFontSize.Clear;
   FStyleColors.Clear;
-  FStyleBorderStyle.Clear;
-  FStyleBorderColor.Clear;
+  FStyleFontColor.Clear;
+  FStyleBorderTopStyle.Clear;
+  FStyleBorderTopColor.Clear;
+  FStyleBorderRightStyle.Clear;
+  FStyleBorderRightColor.Clear;
+  FStyleBorderBottomStyle.Clear;
+  FStyleBorderBottomColor.Clear;
+  FStyleBorderLeftStyle.Clear;
+  FStyleBorderLeftColor.Clear;
   FStyleHAlign.Clear;
   FStyleVAlign.Clear;
   FStyleWrapText.Clear;
-  FStyleFontColor.Clear;
 
   var FontsBold := TList<Boolean>.Create;
   var FontsItalic := TList<Boolean>.Create;
@@ -1436,8 +1540,14 @@ begin
   var FontsName := TList<string>.Create;
   var FontsSize := TList<Double>.Create;
   var Fills := TList<Cardinal>.Create;
-  var BorderStyles := TList<TExcelBorderStyle>.Create;
-  var BorderColors := TList<Cardinal>.Create;
+  var TopStyles := TList<TExcelBorderStyle>.Create;
+  var TopColors := TList<Cardinal>.Create;
+  var RightStyles := TList<TExcelBorderStyle>.Create;
+  var RightColors := TList<Cardinal>.Create;
+  var BottomStyles := TList<TExcelBorderStyle>.Create;
+  var BottomColors := TList<Cardinal>.Create;
+  var LeftStyles := TList<TExcelBorderStyle>.Create;
+  var LeftColors := TList<Cardinal>.Create;
   var FontsColor := TList<Cardinal>.Create;
   try
     const FontMatches = TRegEx.Matches(Xml, '<font>(.*?)</font>', [roIgnoreCase, roSingleLine]);
@@ -1518,24 +1628,34 @@ begin
     const BorderMatches = TRegEx.Matches(Xml, '<border\s*/>', [roIgnoreCase]);
     for var Match in BorderMatches do
     begin
-      BorderStyles.Add(TExcelBorderStyle.None);
-      BorderColors.Add(0);
+      TopStyles.Add(TExcelBorderStyle.None);
+      TopColors.Add(0);
+      RightStyles.Add(TExcelBorderStyle.None);
+      RightColors.Add(0);
+      BottomStyles.Add(TExcelBorderStyle.None);
+      BottomColors.Add(0);
+      LeftStyles.Add(TExcelBorderStyle.None);
+      LeftColors.Add(0);
     end;
     const BorderFullMatches = TRegEx.Matches(Xml, '<border>(.*?)</border>', [roIgnoreCase, roSingleLine]);
     for var Match in BorderFullMatches do
     begin
       const BorderXml = Match.Groups[1].Value;
-      const LeftMatch = TRegEx.Match(BorderXml, '<left\s+style="([^"]*)"', [roIgnoreCase]);
-      if LeftMatch.Success then
-        BorderStyles.Add(StringToBorderStyle(LeftMatch.Groups[1].Value))
-      else
-        BorderStyles.Add(TExcelBorderStyle.None);
+      var AStyle: TExcelBorderStyle;
+      var AColor: Cardinal;
 
-      const BColorMatch = TRegEx.Match(BorderXml, '<left[^>]*>.*?<color\s+rgb="FF([0-9A-Fa-f]{6})"', [roIgnoreCase, roSingleLine]);
-      if BColorMatch.Success then
-        BorderColors.Add(StrToInt64Def('$' + BColorMatch.Groups[1].Value, 0))
-      else
-        BorderColors.Add(0);
+      ParseSide(BorderXml, 'top', AStyle, AColor);
+      TopStyles.Add(AStyle);
+      TopColors.Add(AColor);
+      ParseSide(BorderXml, 'right', AStyle, AColor);
+      RightStyles.Add(AStyle);
+      RightColors.Add(AColor);
+      ParseSide(BorderXml, 'bottom', AStyle, AColor);
+      BottomStyles.Add(AStyle);
+      BottomColors.Add(AColor);
+      ParseSide(BorderXml, 'left', AStyle, AColor);
+      LeftStyles.Add(AStyle);
+      LeftColors.Add(AColor);
     end;
 
     const CellXfsMatch = TRegEx.Match(Xml, '<cellXfs[^>]*>(.*?)</cellXfs>', [roIgnoreCase, roSingleLine]);
@@ -1551,11 +1671,6 @@ begin
         var FontId := 0;
         if FontIdMatch.Success then
           FontId := StrToIntDef(FontIdMatch.Groups[1].Value, 0);
-
-        var FColor: Cardinal := 0;
-        if FontId < FontsColor.Count then
-          FColor := FontsColor[FontId];
-        FStyleFontColor.Add(FColor);
 
         const FillIdMatch = TRegEx.Match(XfXml, 'fillId="(\d+)"', [roIgnoreCase]);
         var FillId := 0;
@@ -1588,15 +1703,43 @@ begin
           BgColor := Fills[FillId];
         FStyleColors.Add(BgColor);
 
-        if BorderId < BorderStyles.Count then
-          FStyleBorderStyle.Add(BorderStyles[BorderId])
-        else
-          FStyleBorderStyle.Add(TExcelBorderStyle.None);
+        var FColor: Cardinal := 0;
+        if FontId < FontsColor.Count then
+          FColor := FontsColor[FontId];
+        FStyleFontColor.Add(FColor);
 
-        if BorderId < BorderColors.Count then
-          FStyleBorderColor.Add(BorderColors[BorderId])
+        if BorderId < TopStyles.Count then
+          FStyleBorderTopStyle.Add(TopStyles[BorderId])
         else
-          FStyleBorderColor.Add(0);
+          FStyleBorderTopStyle.Add(TExcelBorderStyle.None);
+        if BorderId < TopColors.Count then
+          FStyleBorderTopColor.Add(TopColors[BorderId])
+        else
+          FStyleBorderTopColor.Add(0);
+        if BorderId < RightStyles.Count then
+          FStyleBorderRightStyle.Add(RightStyles[BorderId])
+        else
+          FStyleBorderRightStyle.Add(TExcelBorderStyle.None);
+        if BorderId < RightColors.Count then
+          FStyleBorderRightColor.Add(RightColors[BorderId])
+        else
+          FStyleBorderRightColor.Add(0);
+        if BorderId < BottomStyles.Count then
+          FStyleBorderBottomStyle.Add(BottomStyles[BorderId])
+        else
+          FStyleBorderBottomStyle.Add(TExcelBorderStyle.None);
+        if BorderId < BottomColors.Count then
+          FStyleBorderBottomColor.Add(BottomColors[BorderId])
+        else
+          FStyleBorderBottomColor.Add(0);
+        if BorderId < LeftStyles.Count then
+          FStyleBorderLeftStyle.Add(LeftStyles[BorderId])
+        else
+          FStyleBorderLeftStyle.Add(TExcelBorderStyle.None);
+        if BorderId < LeftColors.Count then
+          FStyleBorderLeftColor.Add(LeftColors[BorderId])
+        else
+          FStyleBorderLeftColor.Add(0);
 
         const AlignMatch = TRegEx.Match(XfXml, '<alignment([^/]*)/>', [roIgnoreCase]);
         if AlignMatch.Success then
@@ -1623,8 +1766,14 @@ begin
       end;
     end;
   finally
-    BorderColors.Free;
-    BorderStyles.Free;
+    LeftColors.Free;
+    LeftStyles.Free;
+    BottomColors.Free;
+    BottomStyles.Free;
+    RightColors.Free;
+    RightStyles.Free;
+    TopColors.Free;
+    TopStyles.Free;
     Fills.Free;
     FontSColor.Free;
     FontsSize.Free;
@@ -1860,10 +2009,22 @@ begin
             Cell.FBackgroundColor := FStyleColors[StyleIdx];
           if (StyleIdx < FStyleFontColor.Count) and (FStyleFontColor[StyleIdx] <> 0) then
             Cell.FFontColor := FStyleFontColor[StyleIdx];
-          if (StyleIdx < FStyleBorderStyle.Count) and (FStyleBorderStyle[StyleIdx] <> TExcelBorderStyle.None) then
-            Cell.FBorderStyle := FStyleBorderStyle[StyleIdx];
-          if (StyleIdx < FStyleBorderColor.Count) and (FStyleBorderColor[StyleIdx] <> 0) then
-            Cell.FBorderColor := FStyleBorderColor[StyleIdx];
+          if (StyleIdx < FStyleBorderTopStyle.Count) and (FStyleBorderTopStyle[StyleIdx] <> TExcelBorderStyle.None) then
+            Cell.FBorderStyle[TExcelBorderSide.Top] := FStyleBorderTopStyle[StyleIdx];
+          if (StyleIdx < FStyleBorderTopColor.Count) and (FStyleBorderTopColor[StyleIdx] <> 0) then
+            Cell.FBorderColor[TExcelBorderSide.Top] := FStyleBorderTopColor[StyleIdx];
+          if (StyleIdx < FStyleBorderRightStyle.Count) and (FStyleBorderRightStyle[StyleIdx] <> TExcelBorderStyle.None) then
+            Cell.FBorderStyle[TExcelBorderSide.Right] := FStyleBorderRightStyle[StyleIdx];
+          if (StyleIdx < FStyleBorderRightColor.Count) and (FStyleBorderRightColor[StyleIdx] <> 0) then
+            Cell.FBorderColor[TExcelBorderSide.Right] := FStyleBorderRightColor[StyleIdx];
+          if (StyleIdx < FStyleBorderBottomStyle.Count) and (FStyleBorderBottomStyle[StyleIdx] <> TExcelBorderStyle.None) then
+            Cell.FBorderStyle[TExcelBorderSide.Bottom] := FStyleBorderBottomStyle[StyleIdx];
+          if (StyleIdx < FStyleBorderBottomColor.Count) and (FStyleBorderBottomColor[StyleIdx] <> 0) then
+            Cell.FBorderColor[TExcelBorderSide.Bottom] := FStyleBorderBottomColor[StyleIdx];
+          if (StyleIdx < FStyleBorderLeftStyle.Count) and (FStyleBorderLeftStyle[StyleIdx] <> TExcelBorderStyle.None) then
+            Cell.FBorderStyle[TExcelBorderSide.Left] := FStyleBorderLeftStyle[StyleIdx];
+          if (StyleIdx < FStyleBorderLeftColor.Count) and (FStyleBorderLeftColor[StyleIdx] <> 0) then
+            Cell.FBorderColor[TExcelBorderSide.Left] := FStyleBorderLeftColor[StyleIdx];
           if (StyleIdx < FStyleHAlign.Count) and (FStyleHAlign[StyleIdx] <> TExcelHAlign.None) then
             Cell.FHAlign := FStyleHAlign[StyleIdx];
           if (StyleIdx < FStyleVAlign.Count) and (FStyleVAlign[StyleIdx] <> TExcelVAlign.None) then
@@ -1904,10 +2065,22 @@ begin
           Cell.FBackgroundColor := FStyleColors[StyleIdx];
         if (StyleIdx < FStyleFontColor.Count) and (FStyleFontColor[StyleIdx] <> 0) then
           Cell.FFontColor := FStyleFontColor[StyleIdx];
-        if (StyleIdx < FStyleBorderStyle.Count) and (FStyleBorderStyle[StyleIdx] <> TExcelBorderStyle.None) then
-          Cell.FBorderStyle := FStyleBorderStyle[StyleIdx];
-        if (StyleIdx < FStyleBorderColor.Count) and (FStyleBorderColor[StyleIdx] <> 0) then
-          Cell.FBorderColor := FStyleBorderColor[StyleIdx];
+        if (StyleIdx < FStyleBorderTopStyle.Count) and (FStyleBorderTopStyle[StyleIdx] <> TExcelBorderStyle.None) then
+          Cell.FBorderStyle[TExcelBorderSide.Top] := FStyleBorderTopStyle[StyleIdx];
+        if (StyleIdx < FStyleBorderTopColor.Count) and (FStyleBorderTopColor[StyleIdx] <> 0) then
+          Cell.FBorderColor[TExcelBorderSide.Top] := FStyleBorderTopColor[StyleIdx];
+        if (StyleIdx < FStyleBorderRightStyle.Count) and (FStyleBorderRightStyle[StyleIdx] <> TExcelBorderStyle.None) then
+          Cell.FBorderStyle[TExcelBorderSide.Right] := FStyleBorderRightStyle[StyleIdx];
+        if (StyleIdx < FStyleBorderRightColor.Count) and (FStyleBorderRightColor[StyleIdx] <> 0) then
+          Cell.FBorderColor[TExcelBorderSide.Right] := FStyleBorderRightColor[StyleIdx];
+        if (StyleIdx < FStyleBorderBottomStyle.Count) and (FStyleBorderBottomStyle[StyleIdx] <> TExcelBorderStyle.None) then
+          Cell.FBorderStyle[TExcelBorderSide.Bottom] := FStyleBorderBottomStyle[StyleIdx];
+        if (StyleIdx < FStyleBorderBottomColor.Count) and (FStyleBorderBottomColor[StyleIdx] <> 0) then
+          Cell.FBorderColor[TExcelBorderSide.Bottom] := FStyleBorderBottomColor[StyleIdx];
+        if (StyleIdx < FStyleBorderLeftStyle.Count) and (FStyleBorderLeftStyle[StyleIdx] <> TExcelBorderStyle.None) then
+          Cell.FBorderStyle[TExcelBorderSide.Left] := FStyleBorderLeftStyle[StyleIdx];
+        if (StyleIdx < FStyleBorderLeftColor.Count) and (FStyleBorderLeftColor[StyleIdx] <> 0) then
+          Cell.FBorderColor[TExcelBorderSide.Left] := FStyleBorderLeftColor[StyleIdx];
         if (StyleIdx < FStyleHAlign.Count) and (FStyleHAlign[StyleIdx] <> TExcelHAlign.None) then
           Cell.FHAlign := FStyleHAlign[StyleIdx];
         if (StyleIdx < FStyleVAlign.Count) and (FStyleVAlign[StyleIdx] <> TExcelVAlign.None) then

--- a/Source/Excel/Office4D.Excel.pas
+++ b/Source/Excel/Office4D.Excel.pas
@@ -13,6 +13,8 @@ type
   TExcelBorderStyle = (None, Thin, Medium, Thick, Dashed, Dotted, Double);
   TExcelHAlign = (None, Left, Center, Right, Justify);
   TExcelVAlign = (None, Top, Center, Bottom);
+  TExcelBorderSide = (Top, Right, Bottom, Left);
+  TExcelBorderSides = set of TExcelBorderSide;
   {$SCOPEDENUMS OFF}
 
   IExcelCell = interface;
@@ -46,10 +48,10 @@ type
     procedure SetBackgroundColor(const Value: Cardinal);
     function GetNumberFormat: string;
     procedure SetNumberFormat(const Value: string);
-    function GetBorderStyle: TExcelBorderStyle;
-    procedure SetBorderStyle(const Value: TExcelBorderStyle);
-    function GetBorderColor: Cardinal;
-    procedure SetBorderColor(const Value: Cardinal);
+    function GetBorderStyle(ASides: TExcelBorderSides): TExcelBorderStyle;
+    procedure SetBorderStyle(ASides: TExcelBorderSides; const Value: TExcelBorderStyle);
+    function GetBorderColor(ASides: TExcelBorderSides): Cardinal;
+    procedure SetBorderColor(ASides: TExcelBorderSides; const Value: Cardinal);
     function GetHAlign: TExcelHAlign;
     procedure SetHAlign(const Value: TExcelHAlign);
     function GetVAlign: TExcelVAlign;
@@ -72,8 +74,8 @@ type
     property FontSize: Double read GetFontSize write SetFontSize;
     property BackgroundColor: Cardinal read GetBackgroundColor write SetBackgroundColor;
     property NumberFormat: string read GetNumberFormat write SetNumberFormat;
-    property BorderStyle: TExcelBorderStyle read GetBorderStyle write SetBorderStyle;
-    property BorderColor: Cardinal read GetBorderColor write SetBorderColor;
+    property BorderStyle[ASides: TExcelBorderSides]: TExcelBorderStyle read GetBorderStyle write SetBorderStyle;
+    property BorderColor[ASides: TExcelBorderSides]: Cardinal read GetBorderColor write SetBorderColor;
     property HAlign: TExcelHAlign read GetHAlign write SetHAlign;
     property VAlign: TExcelVAlign read GetVAlign write SetVAlign;
     property WrapText: Boolean read GetWrapText write SetWrapText;
@@ -125,6 +127,9 @@ type
   public
     class function Create: IExcelWorkbook;
   end;
+
+const
+  AllBorderSides: TExcelBorderSides = [TExcelBorderSide.Top, TExcelBorderSide.Right, TExcelBorderSide.Bottom, TExcelBorderSide.Left];
 
 implementation
 

--- a/Tests/Source/Office4D.Tests.Excel.BorderSides.pas
+++ b/Tests/Source/Office4D.Tests.Excel.BorderSides.pas
@@ -1,0 +1,373 @@
+unit Office4D.Tests.Excel.BorderSides;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  System.RegularExpressions,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelBorderSidesTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FTempFile: string;
+
+    function ExtractCellStyleIndex(const SheetXml, CellRef: string): Integer;
+
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure SaveToFile_DifferentTopBorderColors_ProduceDifferentStyleIndices;
+
+    [Test]
+    procedure SaveToFile_BorderOnlyCell_WritesStyledEmptyCell;
+
+    [Test]
+    procedure RoundTrip_UniformBorderSetter_AppliesToAllFourSides;
+
+    [Test]
+    procedure SaveToFile_PlainCell_HasNoStyleAttribute;
+
+    [Test]
+    procedure RoundTrip_MixedSideBorders_PreservesEachSideIndependently;
+
+    [Test]
+    procedure RoundTrip_OutlinePattern_ProducesCorrectSideCountPerPosition;
+
+    [Test]
+    procedure GetBorderStyle_MultiSideQuery_ReturnsFirstMatchingSideInOrder;
+
+    [Test]
+    procedure SaveToFile_ColorWithoutStyle_ProducesNoBorderElement;
+
+    [Test]
+    procedure LoadFromFile_AsymmetricBottomOnlyBorder_ReadsAllFourSidesIndependently;
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  System.Zip,
+  Office4D.Package;
+
+{ TExcelBorderSidesTests }
+
+procedure TExcelBorderSidesTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'border_test_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelBorderSidesTests.TearDown;
+begin
+  FWorkbook := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+function TExcelBorderSidesTests.ExtractCellStyleIndex(const SheetXml, CellRef: string): Integer;
+var
+  M: TMatch;
+begin
+  M := TRegEx.Match(SheetXml, '<c\s+r="' + CellRef + '"[^>]*\ss="(\d+)"', [roIgnoreCase]);
+  if M.Success then
+    Result := StrToIntDef(M.Groups[1].Value, 0)
+  else
+    Result := 0; // no s= attribute present means the default style, index 0
+end;
+
+procedure TExcelBorderSidesTests.SaveToFile_DifferentTopBorderColors_ProduceDifferentStyleIndices;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  Sheet.Cell['A1'].BorderStyle[[TExcelBorderSide.Top]] := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderColor[[TExcelBorderSide.Top]] := $FF0000;
+
+  Sheet.Cell['B1'].BorderStyle[[TExcelBorderSide.Top]] := TExcelBorderStyle.Thin;
+  Sheet.Cell['B1'].BorderColor[[TExcelBorderSide.Top]] := $0000FF;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    const IdxA1 = ExtractCellStyleIndex(SheetXml, 'A1');
+    const IdxB1 = ExtractCellStyleIndex(SheetXml, 'B1');
+
+    Assert.AreNotEqual(IdxA1, IdxB1,
+      'Cells with different top border colors must resolve to different style indices -- ' +
+      'a failure here means the style-key field order/count has drifted');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelBorderSidesTests.SaveToFile_BorderOnlyCell_WritesStyledEmptyCell;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].BorderStyle[[TExcelBorderSide.Bottom]] := TExcelBorderStyle.Thin;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsTrue(Pos('r="A1" s="', SheetXml) > 0,
+      'A cell with only a border side set must still be written with a non-default style, ' +
+      'even though it has no value and no other formatting');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelBorderSidesTests.RoundTrip_UniformBorderSetter_AppliesToAllFourSides;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Boxed';
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Medium;
+  Sheet.Cell['A1'].BorderColor[AllBorderSides] := $123456;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Cell = Workbook2.Sheets[0].Cell['A1'];
+
+  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle[[TExcelBorderSide.Top]]), 'Top style');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle[[TExcelBorderSide.Right]]), 'Right style');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle[[TExcelBorderSide.Bottom]]), 'Bottom style');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle[[TExcelBorderSide.Left]]), 'Left style');
+  Assert.AreEqual(Cardinal($123456), Cell.BorderColor[[TExcelBorderSide.Top]], 'Top color');
+  Assert.AreEqual(Cardinal($123456), Cell.BorderColor[[TExcelBorderSide.Right]], 'Right color');
+  Assert.AreEqual(Cardinal($123456), Cell.BorderColor[[TExcelBorderSide.Bottom]], 'Bottom color');
+  Assert.AreEqual(Cardinal($123456), Cell.BorderColor[[TExcelBorderSide.Left]], 'Left color');
+end;
+
+procedure TExcelBorderSidesTests.SaveToFile_PlainCell_HasNoStyleAttribute;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Plain';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsFalse(Pos('r="A1" s="', SheetXml) > 0,
+      'A cell with no formatting at all must resolve to the default style (index 0) and ' +
+      'carry no s= attribute');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelBorderSidesTests.RoundTrip_MixedSideBorders_PreservesEachSideIndependently;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'X';
+  Sheet.Cell['A1'].BorderStyle[[TExcelBorderSide.Top]] := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderColor[[TExcelBorderSide.Top]] := $000000;
+  Sheet.Cell['A1'].BorderStyle[[TExcelBorderSide.Right]] := TExcelBorderStyle.Thick;
+  Sheet.Cell['A1'].BorderColor[[TExcelBorderSide.Right]] := $FF0000;
+  // Bottom deliberately left as None -- the one side that must NOT come back set.
+  Sheet.Cell['A1'].BorderStyle[[TExcelBorderSide.Left]] := TExcelBorderStyle.Dashed;
+  Sheet.Cell['A1'].BorderColor[[TExcelBorderSide.Left]] := $0000FF;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Cell = Workbook2.Sheets[0].Cell['A1'];
+
+  Assert.AreEqual(Ord(TExcelBorderStyle.Thin), Ord(Cell.BorderStyle[[TExcelBorderSide.Top]]), 'Top style survives round-trip');
+  Assert.AreEqual(Cardinal($000000), Cell.BorderColor[[TExcelBorderSide.Top]], 'Top color survives round-trip');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Thick), Ord(Cell.BorderStyle[[TExcelBorderSide.Right]]), 'Right style survives round-trip');
+  Assert.AreEqual(Cardinal($FF0000), Cell.BorderColor[[TExcelBorderSide.Right]], 'Right color survives round-trip');
+  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Cell.BorderStyle[[TExcelBorderSide.Bottom]]), 'Bottom correctly stayed unset');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Dashed), Ord(Cell.BorderStyle[[TExcelBorderSide.Left]]), 'Left style survives round-trip');
+  Assert.AreEqual(Cardinal($0000FF), Cell.BorderColor[[TExcelBorderSide.Left]], 'Left color survives round-trip');
+end;
+
+procedure TExcelBorderSidesTests.RoundTrip_OutlinePattern_ProducesCorrectSideCountPerPosition;
+const
+  Cols: array[0..2] of string = ('A', 'B', 'C');
+var
+  c, r, SideCount: Integer;
+  Addr: string;
+  Side: TExcelBorderSide;
+  Sides: TExcelBorderSides;
+  Cell: IExcelCell;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  for c := 0 to 2 do
+    for r := 0 to 2 do
+    begin
+      Addr := Cols[c] + IntToStr(r + 1);
+      Cell := Sheet.Cell[Addr];
+
+      Sides := [];
+      if r = 0 then Include(Sides, TExcelBorderSide.Top);
+      if r = 2 then Include(Sides, TExcelBorderSide.Bottom);
+      if c = 0 then Include(Sides, TExcelBorderSide.Left);
+      if c = 2 then Include(Sides, TExcelBorderSide.Right);
+
+      if Sides <> [] then
+      begin
+        Cell.BorderStyle[Sides] := TExcelBorderStyle.Thin;
+        Cell.BorderColor[Sides] := $000000;
+      end;
+    end;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Sheet2 = Workbook2.Sheets[0];
+
+  for c := 0 to 2 do
+    for r := 0 to 2 do
+    begin
+      Addr := Cols[c] + IntToStr(r + 1);
+      Cell := Sheet2.Cell[Addr];
+
+      SideCount := 0;
+      for Side := Low(TExcelBorderSide) to High(TExcelBorderSide) do
+        if Cell.BorderStyle[[Side]] <> TExcelBorderStyle.None then
+          Inc(SideCount);
+
+      if (c = 1) and (r = 1) then
+        Assert.AreEqual(0, SideCount, 'Center cell must have zero border sides')
+      else if ((c = 0) or (c = 2)) and ((r = 0) or (r = 2)) then
+        Assert.AreEqual(2, SideCount, Format('Corner cell %s must have exactly two sides', [Addr]))
+      else
+        Assert.AreEqual(1, SideCount, Format('Edge-midpoint cell %s must have exactly one side', [Addr]));
+    end;
+end;
+
+procedure TExcelBorderSidesTests.GetBorderStyle_MultiSideQuery_ReturnsFirstMatchingSideInOrder;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+  Cell.BorderStyle[[TExcelBorderSide.Top]] := TExcelBorderStyle.Thin;
+  Cell.BorderStyle[[TExcelBorderSide.Left]] := TExcelBorderStyle.Thick;
+
+  // Documented contract: returns the first matching side in Top/Right/Bottom/Left
+  // declaration order -- Top wins here even though Left was also set to a different value.
+  Assert.AreEqual(Ord(TExcelBorderStyle.Thin), Ord(Cell.BorderStyle[[TExcelBorderSide.Top, TExcelBorderSide.Left]]),
+    'Querying [ebsTop, ebsLeft] together must return the Top value per the documented ' +
+    'first-match-in-enum-order contract');
+end;
+
+procedure TExcelBorderSidesTests.SaveToFile_ColorWithoutStyle_ProducesNoBorderElement;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'X';
+  Sheet.Cell['A1'].BorderColor[[TExcelBorderSide.Top]] := $FF0000; // color set, style left at None
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    // A1 is the only formatted cell in this file, so if any <top style="..."> element
+    // appears anywhere in styles.xml, it can only have come from this cell -- and it
+    // shouldn't, since BorderStyle was never set (color alone must not render a visible side).
+    Assert.IsFalse(Pos('<top style=', StylesXml) > 0,
+      'Setting BorderColor without BorderStyle must not render a visible <top> border side');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelBorderSidesTests.LoadFromFile_AsymmetricBottomOnlyBorder_ReadsAllFourSidesIndependently;
+const
+  ContentTypesXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+    '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+    '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+    '</Types>';
+  RelsXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+    '</Relationships>';
+  WorkbookXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+    '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>';
+  // Realistic shape of what Excel itself writes for a bottom-only border: the other
+  // three sides are present as empty self-closing elements, not omitted -- only
+  // <bottom> carries style + color.
+  StylesXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+    '<fills count="2"><fill><patternFill patternType="none"/></fill>' +
+    '<fill><patternFill patternType="gray125"/></fill></fills>' +
+    '<borders count="2">' +
+    '<border><left/><right/><top/><bottom/></border>' +
+    '<border><left/><right/><top/><bottom style="thin"><color rgb="FF000000"/></bottom></border>' +
+    '</borders>' +
+    '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+    '<cellXfs count="2">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1"/>' +
+    '</cellXfs></styleSheet>';
+  // A1 self-closing with no value -- the common "empty cell under a header, styled
+  // with just a bottom rule" case, which also exercises the empty-styled-cell parse path.
+  SheetXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1" s="1"/></row></sheetData></worksheet>';
+begin
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(FTempFile, zmWrite);
+    Zip.Add(TEncoding.UTF8.GetBytes(ContentTypesXml), '[Content_Types].xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(RelsXml), '_rels/.rels');
+    Zip.Add(TEncoding.UTF8.GetBytes(WorkbookXml), 'xl/workbook.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(StylesXml), 'xl/styles.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(SheetXml), 'xl/worksheets/sheet1.xml');
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Cell = Workbook2.Sheets[0].Cell['A1'];
+
+  // This is the exact case ParseStyles used to get wrong -- it only ever read <left>,
+  // so a bottom-only border like this would previously have been silently dropped.
+  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Cell.BorderStyle[[TExcelBorderSide.Top]]), 'Top must read as None');
+  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Cell.BorderStyle[[TExcelBorderSide.Left]]), 'Left must read as None');
+  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Cell.BorderStyle[[TExcelBorderSide.Right]]), 'Right must read as None');
+  Assert.AreEqual(Ord(TExcelBorderStyle.Thin), Ord(Cell.BorderStyle[[TExcelBorderSide.Bottom]]), 'Bottom must read as Thin');
+  Assert.AreEqual(Cardinal($000000), Cell.BorderColor[[TExcelBorderSide.Bottom]], 'Bottom color must read correctly');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelBorderSidesTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -860,7 +860,7 @@ procedure TExcelWriteTests.SaveToFile_WithBorderThin_ContainsBorderStyle;
 begin
   const Sheet = FWorkbook.AddSheet('Sheet1');
   Sheet.Cell['A1'].AsString := 'Bordered';
-  Sheet.Cell['A1'].BorderStyle := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Thin;
 
   FWorkbook.SaveToFile(FTempFile);
 
@@ -878,7 +878,7 @@ procedure TExcelWriteTests.RoundTrip_BorderThin_PreservesBorder;
 begin
   const Sheet = FWorkbook.AddSheet('Sheet1');
   Sheet.Cell['A1'].AsString := 'Bordered';
-  Sheet.Cell['A1'].BorderStyle := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Thin;
   Sheet.Cell['B1'].AsString := 'No border';
 
   FWorkbook.SaveToFile(FTempFile);
@@ -886,16 +886,16 @@ begin
   const Workbook2 = TExcelWorkbookFactory.Create;
   Workbook2.LoadFromFile(FTempFile);
 
-  Assert.AreEqual(Ord(TExcelBorderStyle.Thin), Ord(Workbook2.Sheets[0].Cell['A1'].BorderStyle));
-  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Workbook2.Sheets[0].Cell['B1'].BorderStyle));
+  Assert.AreEqual(Ord(TExcelBorderStyle.Thin), Ord(Workbook2.Sheets[0].Cell['A1'].BorderStyle[AllBorderSides]));
+  Assert.AreEqual(Ord(TExcelBorderStyle.None), Ord(Workbook2.Sheets[0].Cell['B1'].BorderStyle[AllBorderSides]));
 end;
 
 procedure TExcelWriteTests.SaveToFile_WithBorderColor_ContainsBorderColor;
 begin
   const Sheet = FWorkbook.AddSheet('Sheet1');
   Sheet.Cell['A1'].AsString := 'Red border';
-  Sheet.Cell['A1'].BorderStyle := TExcelBorderStyle.Thin;
-  Sheet.Cell['A1'].BorderColor := $FF0000;
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderColor[AllBorderSides] := $FF0000;
 
   FWorkbook.SaveToFile(FTempFile);
 
@@ -913,15 +913,15 @@ procedure TExcelWriteTests.RoundTrip_BorderColor_PreservesBorderColor;
 begin
   const Sheet = FWorkbook.AddSheet('Sheet1');
   Sheet.Cell['A1'].AsString := 'Red border';
-  Sheet.Cell['A1'].BorderStyle := TExcelBorderStyle.Thin;
-  Sheet.Cell['A1'].BorderColor := $FF0000;
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Thin;
+  Sheet.Cell['A1'].BorderColor[AllBorderSides] := $FF0000;
 
   FWorkbook.SaveToFile(FTempFile);
 
   const Workbook2 = TExcelWorkbookFactory.Create;
   Workbook2.LoadFromFile(FTempFile);
 
-  Assert.AreEqual(Cardinal($FF0000), Workbook2.Sheets[0].Cell['A1'].BorderColor);
+  Assert.AreEqual(Cardinal($FF0000), Workbook2.Sheets[0].Cell['A1'].BorderColor[AllBorderSides]);
 end;
 
 procedure TExcelWriteTests.SaveToFile_WithHAlign_ContainsAlignmentXml;
@@ -1035,8 +1035,8 @@ begin
   Sheet.Cell['A1'].FontName := 'Arial';
   Sheet.Cell['A1'].FontSize := 14;
   Sheet.Cell['A1'].BackgroundColor := $FFFF00;
-  Sheet.Cell['A1'].BorderStyle := TExcelBorderStyle.Medium;
-  Sheet.Cell['A1'].BorderColor := $0000FF;
+  Sheet.Cell['A1'].BorderStyle[AllBorderSides] := TExcelBorderStyle.Medium;
+  Sheet.Cell['A1'].BorderColor[AllBorderSides] := $0000FF;
   Sheet.Cell['A1'].HAlign := TExcelHAlign.Center;
   Sheet.Cell['A1'].VAlign := TExcelVAlign.Bottom;
   Sheet.Cell['A1'].WrapText := True;
@@ -1055,8 +1055,8 @@ begin
   Assert.AreEqual('Arial', Cell.FontName);
   Assert.AreEqual(Double(14), Cell.FontSize, 0.01);
   Assert.AreEqual(Cardinal($FFFF00), Cell.BackgroundColor);
-  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle));
-  Assert.AreEqual(Cardinal($0000FF), Cell.BorderColor);
+  Assert.AreEqual(Ord(TExcelBorderStyle.Medium), Ord(Cell.BorderStyle[AllBorderSides]));
+  Assert.AreEqual(Cardinal($0000FF), Cell.BorderColor[AllBorderSides]);
   Assert.AreEqual(Ord(TExcelHAlign.Center), Ord(Cell.HAlign));
   Assert.AreEqual(Ord(TExcelVAlign.Bottom), Ord(Cell.VAlign));
   Assert.IsTrue(Cell.WrapText, 'Should have wrapText');

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -29,7 +29,8 @@ uses
   Office4D.Tests.Word.Write in 'Office4D.Tests.Word.Write.pas',
   Office4D.Tests.Excel in 'Office4D.Tests.Excel.pas',
   Office4D.Tests.Excel.Write in 'Office4D.Tests.Excel.Write.pas',
-  Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas';
+  Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas',
+  Office4D.Tests.Excel.BorderSides in 'Office4D.Tests.Excel.BorderSides.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Source/Office4D.Tests.dproj
+++ b/Tests/Source/Office4D.Tests.dproj
@@ -5,33 +5,13 @@
         <Base>True</Base>
         <Config Condition="'$(Config)'==''">Debug</Config>
         <ProjectName Condition="'$(ProjectName)'==''">Office4D.Tests</ProjectName>
-        <TargetedPlatforms>129</TargetedPlatforms>
+        <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Console</AppType>
         <FrameworkType>None</FrameworkType>
         <ProjectVersion>20.3</ProjectVersion>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
-        <Base_Android>true</Base_Android>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSDevice32' and '$(Base)'=='true') or '$(Base_iOSDevice32)'!=''">
-        <Base_iOSDevice32>true</Base_iOSDevice32>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
-        <Base_iOSDevice64>true</Base_iOSDevice64>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSSimulator' and '$(Base)'=='true') or '$(Base_iOSSimulator)'!=''">
-        <Base_iOSSimulator>true</Base_iOSSimulator>
-        <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
@@ -65,61 +45,6 @@
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_Android)'!=''">
-        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
-        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
-        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
-        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
-        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
-        <Android_SplashImage426>$(BDS)\bin\Artwork\Android\FM_SplashImage_426x320.png</Android_SplashImage426>
-        <Android_SplashImage470>$(BDS)\bin\Artwork\Android\FM_SplashImage_470x320.png</Android_SplashImage470>
-        <Android_SplashImage640>$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png</Android_SplashImage640>
-        <Android_SplashImage960>$(BDS)\bin\Artwork\Android\FM_SplashImage_960x720.png</Android_SplashImage960>
-        <AUP_ACCESS_COARSE_LOCATION>true</AUP_ACCESS_COARSE_LOCATION>
-        <AUP_ACCESS_FINE_LOCATION>true</AUP_ACCESS_FINE_LOCATION>
-        <AUP_CALL_PHONE>true</AUP_CALL_PHONE>
-        <AUP_CAMERA>true</AUP_CAMERA>
-        <AUP_INTERNET>true</AUP_INTERNET>
-        <AUP_READ_CALENDAR>true</AUP_READ_CALENDAR>
-        <AUP_READ_EXTERNAL_STORAGE>true</AUP_READ_EXTERNAL_STORAGE>
-        <AUP_WRITE_CALENDAR>true</AUP_WRITE_CALENDAR>
-        <AUP_WRITE_EXTERNAL_STORAGE>true</AUP_WRITE_EXTERNAL_STORAGE>
-        <AUP_READ_PHONE_STATE>true</AUP_READ_PHONE_STATE>
-        <Android_NotificationIcon24>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_24x24.png</Android_NotificationIcon24>
-        <Android_NotificationIcon36>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_36x36.png</Android_NotificationIcon36>
-        <Android_NotificationIcon48>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_48x48.png</Android_NotificationIcon48>
-        <Android_NotificationIcon72>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_72x72.png</Android_NotificationIcon72>
-        <Android_NotificationIcon96>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_96x96.png</Android_NotificationIcon96>
-        <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSDevice32)'!=''">
-        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
-        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
-        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
-        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
-        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
-        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
-        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
-        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
-        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
-        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
-        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
-        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
-        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
-        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
-        <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSSimulator)'!=''">
-        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
-        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
-        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
-        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
-        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
-        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
-        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
-    </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
@@ -147,6 +72,7 @@
         <DCCReference Include="..\..\Source\Core\Office4D.Errors.pas"/>
         <DCCReference Include="..\..\Source\Core\Office4D.Package.pas"/>
         <DCCReference Include="..\..\Source\Core\Office4D.Relationships.pas"/>
+        <DCCReference Include="..\..\Source\Core\Office4D.Xml.pas"/>
         <DCCReference Include="..\..\Source\Common\Office4D.Metadata.pas"/>
         <DCCReference Include="..\..\Source\Word\Office4D.Word.pas"/>
         <DCCReference Include="..\..\Source\Word\Office4D.Word.Document.pas"/>
@@ -163,6 +89,7 @@
         <DCCReference Include="Office4D.Tests.Excel.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.Write.pas"/>
         <DCCReference Include="Office4D.Tests.PowerPoint.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.BorderSides.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -185,12 +112,6 @@
                 </Source>
             </Delphi.Personality>
             <Platforms>
-                <Platform value="Android">False</Platform>
-                <Platform value="iOSDevice32">False</Platform>
-                <Platform value="iOSDevice64">False</Platform>
-                <Platform value="iOSSimulator">False</Platform>
-                <Platform value="Linux64">True</Platform>
-                <Platform value="OSX32">False</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">False</Platform>
             </Platforms>


### PR DESCRIPTION
Changed BorderColor and BorderStyle to be "side"-aware - which would enable doing multi-cell bordering - or common cell "underlining".

Added 9 extra tests

There is a minor breaking change due to this - the properties TExcelCell.BorderColor and TExcelCell.BorderStyle, does not now require a set of TExcelBorderSides - so now indexed. For that reason the is a AllBorderSides const - which has been applied the few place in the original tests.