### PR TITLE
Excel: DateTime read from file, not marked as DateTime CellType

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -113,6 +113,7 @@ type
     procedure SetCellValue(const Address, Value: string; IsString: Boolean);
     procedure SetBooleanValue(const Address: string; Value: Boolean);
     procedure SetCellFormula(const Address, Formula, Value: string);
+    procedure SetDateTimeValue(const Address: string; const Value: Double);
 
     function GetCells: TDictionary<string, IExcelCell>;
 
@@ -139,6 +140,7 @@ type
     FStyleVAlign: TList<TExcelVAlign>;
     FStyleWrapText: TList<Boolean>;
     FStyleFontColor: TList<Cardinal>;
+    FStyleIsDate: TList<Boolean>;
 
     procedure ParseWorkbook(const Xml: string);
     procedure ParseSharedStrings(const Xml: string);
@@ -531,6 +533,16 @@ begin
   Cell.SetAsBoolean(Value);
 end;
 
+procedure TExcelSheet.SetDateTimeValue(const Address: string; const Value: Double);
+begin
+  // Value is the raw Excel serial number as read from <v>. A Delphi
+  // TDateTime and an Excel/OOXML date serial number are the same value
+  // numerically (see TExcelCell.SetAsDateTime), so it can be passed
+  // straight through without any epoch conversion.
+  var Cell := GetCell(Address) as TExcelCell;
+  Cell.SetAsDateTime(Value);
+end;
+
 procedure TExcelSheet.SetCellFormula(const Address, Formula, Value: string);
 begin
   var Cell := GetCell(Address) as TExcelCell;
@@ -558,10 +570,12 @@ begin
   FStyleVAlign := TList<TExcelVAlign>.Create;
   FStyleWrapText := TList<Boolean>.Create;
   FStyleFontColor := TList<Cardinal>.Create;
+  FStyleIsDate := TList<Boolean>.Create;
 end;
 
 destructor TExcelWorkbook.Destroy;
 begin
+  FStyleIsDate.Free;
   FStyleFontColor.Free;
   FStyleWrapText.Free;
   FStyleVAlign.Free;
@@ -1415,6 +1429,43 @@ procedure TExcelWorkbook.ParseStyles(const Xml: string);
     else Result := TExcelVAlign.None;
   end;
 
+  // Built-in numFmtId values 14-22 are the standard date/time formats
+  // (e.g. 14 = m/d/yyyy, 22 = m/d/yyyy h:mm); 45-47 are the built-in
+  // duration/time formats (mm:ss, [h]:mm:ss, mmss.0). IDs 0-163 are
+  // reserved for built-ins; anything else is either "General"/numeric
+  // or unused, so it isn't a date.
+  function IsBuiltInDateNumFmtId(const NumFmtId: Integer): Boolean;
+  begin
+    Result := ((NumFmtId >= 14) and (NumFmtId <= 22)) or
+              ((NumFmtId >= 45) and (NumFmtId <= 47));
+  end;
+
+  // Heuristic used to classify a custom (non-built-in) format code, e.g.
+  // "yyyy-mm-dd" or "dd/mm/yyyy hh:mm". Quoted literal text and bracketed
+  // sections (colour tags like [Red], locale tags like [$-409], or
+  // conditional tags like [>=100]) are stripped first so that literal
+  // text or non-date bracket tags can't be mistaken for date components.
+  // What remains is checked for the date/time placeholder letters
+  // (y, d, h, s, and AM/PM); if any are present the format is a date.
+  // "m" is deliberately excluded on its own, since standalone "m" is
+  // ambiguous with numeric formats, and a month-only format with no
+  // year/day/time component is vanishingly rare in practice.
+  function IsDateFormatCode(const FormatCode: string): Boolean;
+  var
+    Cleaned: string;
+  begin
+    if (FormatCode = '') or SameText(FormatCode, 'General') then
+      Exit(False);
+
+    // Only the first section (before an unescaped ';') applies to
+    // positive values, which is what a date serial number is.
+    Cleaned := TRegEx.Match(FormatCode, '^((?:[^;"\[]|"[^"]*"|\[[^\]]*\])*)').Groups[1].Value;
+    Cleaned := TRegEx.Replace(Cleaned, '"[^"]*"', '', [roIgnoreCase]);
+    Cleaned := TRegEx.Replace(Cleaned, '\[[^\]]*\]', '', [roIgnoreCase]);
+
+    Result := TRegEx.IsMatch(Cleaned, '[ydhsYDHS]') or (Pos('AM/PM', UpperCase(Cleaned)) > 0);
+  end;
+
 begin
   FStyleBold.Clear;
   FStyleItalic.Clear;
@@ -1428,6 +1479,7 @@ begin
   FStyleVAlign.Clear;
   FStyleWrapText.Clear;
   FStyleFontColor.Clear;
+  FStyleIsDate.Clear;
 
   var FontsBold := TList<Boolean>.Create;
   var FontsItalic := TList<Boolean>.Create;
@@ -1438,7 +1490,15 @@ begin
   var BorderStyles := TList<TExcelBorderStyle>.Create;
   var BorderColors := TList<Cardinal>.Create;
   var FontsColor := TList<Cardinal>.Create;
+  var CustomNumFmts := TDictionary<Integer, string>.Create;
   try
+    const NumFmtMatches = TRegEx.Matches(Xml,
+      '<numFmt\s+numFmtId="(\d+)"\s+formatCode="([^"]*)"', [roIgnoreCase]);
+    for var NumFmtMatch in NumFmtMatches do
+      CustomNumFmts.AddOrSetValue(
+        StrToIntDef(NumFmtMatch.Groups[1].Value, -1),
+        TXml.Unescape(NumFmtMatch.Groups[2].Value));
+
     const FontMatches = TRegEx.Matches(Xml, '<font>(.*?)</font>', [roIgnoreCase, roSingleLine]);
     for var Match in FontMatches do
     begin
@@ -1546,6 +1606,19 @@ begin
       begin
         const XfXml = Match.Value;
 
+        const NumFmtIdMatch = TRegEx.Match(XfXml, 'numFmtId="(\d+)"', [roIgnoreCase]);
+        var NumFmtId := 0;
+        if NumFmtIdMatch.Success then
+          NumFmtId := StrToIntDef(NumFmtIdMatch.Groups[1].Value, 0);
+
+        var CustomFormatCode: string;
+        if IsBuiltInDateNumFmtId(NumFmtId) then
+          FStyleIsDate.Add(True)
+        else if CustomNumFmts.TryGetValue(NumFmtId, CustomFormatCode) then
+          FStyleIsDate.Add(IsDateFormatCode(CustomFormatCode))
+        else
+          FStyleIsDate.Add(False);
+
         const FontIdMatch = TRegEx.Match(XfXml, 'fontId="(\d+)"', [roIgnoreCase]);
         var FontId := 0;
         if FontIdMatch.Success then
@@ -1622,6 +1695,7 @@ begin
       end;
     end;
   finally
+    CustomNumFmts.Free;
     BorderColors.Free;
     BorderStyles.Free;
     Fills.Free;
@@ -1839,7 +1913,10 @@ begin
         end
         else
         begin
-          Sheet.SetCellValue(Address, Value, False);
+          if (StyleIdx > 0) and (StyleIdx < FStyleIsDate.Count) and FStyleIsDate[StyleIdx] then
+            Sheet.SetDateTimeValue(Address, StrToFloatDef(Value, 0, TFormatSettings.Invariant))
+          else
+            Sheet.SetCellValue(Address, Value, False);
           Cell := Sheet.GetCell(Address) as TExcelCell;
         end;
 

--- a/Tests/Source/Office4D.Tests.Excel.pas
+++ b/Tests/Source/Office4D.Tests.Excel.pas
@@ -133,6 +133,35 @@ type
   end;
 
   [TestFixture]
+  TExcelDateReadTests = class
+  private
+    FTempFile: string;
+
+    procedure WriteWorkbookWithStyles(const StylesXml, SheetXml: string);
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Load_CellWithBuiltInDateFormat_ReturnsCorrectDate;
+
+    [Test]
+    procedure Load_CellWithCustomDateFormat_ReturnsCorrectDate;
+
+    [Test]
+    procedure Load_CellWithBuiltInDateTimeFormat_ReturnsCorrectDateAndTime;
+
+    [Test]
+    procedure Load_CellWithCurrencyFormat_IsNotMisreadAsDate;
+
+    [Test]
+    procedure Load_CellWithNoStyle_IsNotMisreadAsDate;
+  end;
+
+  [TestFixture]
   TExcelFormulaTests = class(TOffice4DTests)
   private
     FWorkbook: IExcelWorkbook;
@@ -796,6 +825,151 @@ begin
   Assert.AreEqual('Last', Sheet.Cell['D1'].AsString, 'D1 should map to entry 3');
 end;
 
+{ TExcelDateReadTests }
+
+procedure TExcelDateReadTests.Setup;
+begin
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'test_date_read_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelDateReadTests.TearDown;
+begin
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+// Builds a minimal .xlsx by hand (not via this library's own SaveToFile) so
+// these tests exercise the read path in isolation. That matters here
+// specifically: an equal-and-opposite bug on the write side previously
+// masked an epoch bug on the read side in the library's own round-trip
+// tests, so read-side fixtures must not depend on the writer at all.
+procedure TExcelDateReadTests.WriteWorkbookWithStyles(const StylesXml, SheetXml: string);
+const
+  XmlDecl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+  SpreadsheetNs = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+begin
+  const WorkbookXml = XmlDecl +
+    '<workbook xmlns="' + SpreadsheetNs + '"><sheets><sheet name="Sheet1" sheetId="1"/></sheets></workbook>';
+
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(FTempFile, zmWrite);
+    Zip.Add(TEncoding.UTF8.GetBytes(WorkbookXml), 'xl/workbook.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(XmlDecl + StylesXml), 'xl/styles.xml');
+    Zip.Add(TEncoding.UTF8.GetBytes(XmlDecl + SheetXml), 'xl/worksheets/sheet1.xml');
+    Zip.Close;
+  finally
+    Zip.Free;
+  end;
+end;
+
+procedure TExcelDateReadTests.Load_CellWithBuiltInDateFormat_ReturnsCorrectDate;
+begin
+  // numFmtId 14 is the built-in "m/d/yyyy" date format. 45458 is the real
+  // Excel serial number for 2024-06-15 (days since 1899-12-30) - i.e. what
+  // any real .xlsx produced by Excel would actually contain, independent
+  // of this library.
+  WriteWorkbookWithStyles(
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<cellXfs count="2">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+    '<xf numFmtId="14" fontId="0" fillId="0" borderId="0"/>' +
+    '</cellXfs></styleSheet>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1" s="1"><v>45458</v></c></row></sheetData></worksheet>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(EncodeDate(2024, 6, 15), Workbook.Sheets[0].Cell['A1'].AsDateTime, 0.0001,
+    'A date-formatted cell with serial 45458 should read back as 2024-06-15');
+end;
+
+procedure TExcelDateReadTests.Load_CellWithCustomDateFormat_ReturnsCorrectDate;
+begin
+  // A custom (non-built-in) numFmt whose format code is clearly a date
+  // ("yyyy\-mm\-dd", as Excel itself escapes the literal dashes) should be
+  // detected as a date just like a built-in numFmtId would be.
+  WriteWorkbookWithStyles(
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<numFmts count="1"><numFmt numFmtId="164" formatCode="yyyy\-mm\-dd"/></numFmts>' +
+    '<cellXfs count="2">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+    '<xf numFmtId="164" fontId="0" fillId="0" borderId="0"/>' +
+    '</cellXfs></styleSheet>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1" s="1"><v>45458</v></c></row></sheetData></worksheet>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(EncodeDate(2024, 6, 15), Workbook.Sheets[0].Cell['A1'].AsDateTime, 0.0001,
+    'A cell with a custom date-like numFmt should read back as 2024-06-15');
+end;
+
+procedure TExcelDateReadTests.Load_CellWithBuiltInDateTimeFormat_ReturnsCorrectDateAndTime;
+begin
+  // numFmtId 22 is the built-in "m/d/yyyy h:mm" date+time format.
+  // 45458.5 is the Excel serial for 2024-06-15 12:00:00.
+  WriteWorkbookWithStyles(
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<cellXfs count="2">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+    '<xf numFmtId="22" fontId="0" fillId="0" borderId="0"/>' +
+    '</cellXfs></styleSheet>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1" s="1"><v>45458.5</v></c></row></sheetData></worksheet>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  const Expected = EncodeDate(2024, 6, 15) + EncodeTime(12, 0, 0, 0);
+  Assert.AreEqual(Expected, Workbook.Sheets[0].Cell['A1'].AsDateTime, 0.0001,
+    'A date+time-formatted cell with serial 45458.5 should read back as 2024-06-15 12:00:00');
+end;
+
+procedure TExcelDateReadTests.Load_CellWithCurrencyFormat_IsNotMisreadAsDate;
+begin
+  // A custom currency format has no date/time placeholder characters and
+  // must not be misclassified as a date. AsString is used as the probe
+  // here: SetCellValue (the plain-number path) preserves the cell's raw
+  // XML text in AsString, while SetAsDateTime (the date path) does not -
+  // so a wrong classification is visible without depending on the
+  // internal TExcelCell.CellType.
+  WriteWorkbookWithStyles(
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<numFmts count="1"><numFmt numFmtId="164" formatCode="&quot;$&quot;#,##0.00"/></numFmts>' +
+    '<cellXfs count="2">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+    '<xf numFmtId="164" fontId="0" fillId="0" borderId="0"/>' +
+    '</cellXfs></styleSheet>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1" s="1"><v>123.45</v></c></row></sheetData></worksheet>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(Double(123.45), Workbook.Sheets[0].Cell['A1'].AsFloat, 0.001,
+    'Currency-formatted cell should still read back as a plain number');
+  Assert.AreEqual('123.45', Workbook.Sheets[0].Cell['A1'].AsString,
+    'Currency-formatted cell should go through the number path, not the date path');
+end;
+
+procedure TExcelDateReadTests.Load_CellWithNoStyle_IsNotMisreadAsDate;
+begin
+  WriteWorkbookWithStyles(
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs></styleSheet>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<sheetData><row r="1"><c r="A1"><v>123.45</v></c></row></sheetData></worksheet>');
+
+  const Workbook = TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(Double(123.45), Workbook.Sheets[0].Cell['A1'].AsFloat, 0.001);
+  Assert.AreEqual('123.45', Workbook.Sheets[0].Cell['A1'].AsString);
+end;
+
 initialization
   TDUnitX.RegisterTestFixture(TExcelReadTests);
   TDUnitX.RegisterTestFixture(TExcelDOMTests);
@@ -803,5 +977,6 @@ initialization
   TDUnitX.RegisterTestFixture(TExcelFormulaTests);
   TDUnitX.RegisterTestFixture(TExcelLayoutTests);
   TDUnitX.RegisterTestFixture(TExcelSharedStringsTests);
+  TDUnitX.RegisterTestFixture(TExcelDateReadTests);
 
 end.


### PR DESCRIPTION
DateTime read from file, did have Number cell type, and not DateTime type.