### PR TITLE
Adding strikeout property and FontStyle property

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -1,4 +1,4 @@
-unit Office4D.Excel.Workbook;
+﻿unit Office4D.Excel.Workbook;
 
 interface
 
@@ -39,6 +39,7 @@ type
     FVAlign: TExcelVAlign;
     FWrapText: Boolean;
     FFontColor: Cardinal;
+    FStrikeout: Boolean;
   public
     function GetAsString: string;
     procedure SetAsString(const Value: string);
@@ -57,6 +58,8 @@ type
     procedure SetItalic(const Value: Boolean);
     function GetUnderline: Boolean;
     procedure SetUnderline(const Value: Boolean);
+    function GetStrikeout: Boolean;
+    procedure SetStrikeout(const Value: Boolean);
     function GetFontName: string;
     procedure SetFontName(const Value: string);
     function GetFontSize: Double;
@@ -77,6 +80,8 @@ type
     procedure SetWrapText(const Value: Boolean);
     function GetFontColor: Cardinal;
     procedure SetFontColor(const Value: Cardinal);
+    function GetFontStyle: TExcelFontStyles;
+    procedure SetFontStyle(const Value: TExcelFontStyles);
 
     function GetIsString: Boolean;
     function HasStyle: Boolean;
@@ -136,6 +141,7 @@ type
     FStyleBold: TList<Boolean>;
     FStyleItalic: TList<Boolean>;
     FStyleUnderline: TList<Boolean>;
+    FStyleStrikeout: TList<Boolean>;
     FStyleFontName: TList<string>;
     FStyleFontSize: TList<Double>;
     FStyleColors: TList<Cardinal>;
@@ -332,6 +338,16 @@ begin
   FNumberFormat := Value;
 end;
 
+function TExcelCell.GetStrikeout: Boolean;
+begin
+  Result := FStrikeout;
+end;
+
+procedure TExcelCell.SetStrikeout(const Value: Boolean);
+begin
+  FStrikeout := Value;
+end;
+
 function TExcelCell.GetItalic: Boolean;
 begin
   Result := FItalic;
@@ -380,6 +396,23 @@ end;
 procedure TExcelCell.SetFontSize(const Value: Double);
 begin
   FFontSize := Value;
+end;
+
+function TExcelCell.GetFontStyle: TExcelFontStyles;
+begin
+  Result := [];
+  if FBold then Include(Result, TExcelFontStyle.Bold);
+  if FItalic then Include(Result, TExcelFontStyle.Italic);
+  if FUnderline then Include(Result, TExcelFontStyle.Underline);
+  if FStrikeout then Include(Result, TExcelFontStyle.Strikeout);
+end;
+
+procedure TExcelCell.SetFontStyle(const Value: TExcelFontStyles);
+begin
+  FBold := TExcelFontStyle.Bold in Value;
+  FItalic := TExcelFontStyle.Italic in Value;
+  FUnderline := TExcelFontStyle.Underline in Value;
+  FStrikeout := TExcelFontStyle.Strikeout in Value;
 end;
 
 function TExcelCell.GetBorderStyle(ASides: TExcelBorderSides): TExcelBorderStyle;
@@ -444,7 +477,7 @@ end;
 
 function TExcelCell.HasStyle: Boolean;
 begin
-  const HasFont = (FBold) or (FItalic) or (FUnderline) or (FFontName <> '') or (FFontSize <> 0) or (FFontColor <> 0);
+  const HasFont = (FBold) or (FItalic) or (FUnderline) or (FFontName <> '') or (FFontSize <> 0) or (FFontColor <> 0) or (FStrikeout);
   const HasFill = (FBackgroundColor <> 0);
   const HasFormat = (FCellType = TCellType.DateTime);
   var HasBorder := False;
@@ -602,6 +635,7 @@ begin
   FStyleFontSize := TList<Double>.Create;
   FStyleColors := TList<Cardinal>.Create;
   FStyleFontColor := TList<Cardinal>.Create;
+  FStyleStrikeout := TList<Boolean>.Create;
   FStyleBorderTopStyle := TList<TExcelBorderStyle>.Create;
   FStyleBorderTopColor := TList<Cardinal>.Create;
   FStyleBorderRightStyle := TList<TExcelBorderStyle>.Create;
@@ -631,6 +665,7 @@ begin
   FStyleBorderTopColor.Free;
   FStyleBorderTopStyle.Free;
   FStyleFontColor.Free;
+  FStyleStrikeout.Free;
   FStyleColors.Free;
   FStyleFontSize.Free;
   FStyleFontName.Free;
@@ -1140,7 +1175,7 @@ begin
       DateFlag := 2
     else
       DateFlag := 1;
-  Result := Format('%d|%d|%d|%s|%d|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d', [
+  Result := Format('%d|%d|%d|%s|%d|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d', [
     Ord(Cell.FBold),
     Cell.FBackgroundColor,
     DateFlag,
@@ -1160,7 +1195,8 @@ begin
     Ord(Cell.FHAlign),
     Ord(Cell.FVAlign),
     Ord(Cell.FWrapText),
-    Cell.FFontColor
+    Cell.FFontColor,
+    Ord(Cell.FStrikeout)
   ]);
 end;
 
@@ -1281,9 +1317,9 @@ begin
       var FontSizeStr := '';
       if Cell.FFontSize <> 0 then
         FontSizeStr := FormatFloat('0.##', Cell.FFontSize, TFormatSettings.Invariant);
-      const FontKey = Format('%d|%d|%d|%s|%s|%d', [
-        Ord(Cell.FBold), Ord(Cell.FItalic), Ord(Cell.FUnderline), Cell.FFontName, FontSizeStr, Cell.FFontColor]);
-      if (FontKey <> '0|0|0|||0') and (not FontKeys.Contains(FontKey)) then
+      const FontKey = Format('%d|%d|%d|%s|%s|%d|%d', [
+        Ord(Cell.FBold), Ord(Cell.FItalic), Ord(Cell.FUnderline), Cell.FFontName, FontSizeStr, Cell.FFontColor, Ord(Cell.FStrikeout)]);
+      if (FontKey <> '0|0|0|||0|0') and (not FontKeys.Contains(FontKey)) then
         FontKeys.Add(FontKey);
 
       const BorderKey = Format('%d|%d|%d|%d|%d|%d|%d|%d', [
@@ -1323,10 +1359,12 @@ begin
       const Name = FontParts[3];
       const Size = FontParts[4];
       const FontColor = StrToIntDef(FontParts[5], 0);
+      const IsStrikeout = FontParts[6] = '1';
       SB.Append('<font>');
       if IsBold then SB.Append('<b/>');
       if IsItalic then SB.Append('<i/>');
       if IsUnderline then SB.Append('<u/>');
+      if IsStrikeout then SB.Append('<strike/>');
       if Size <> '' then
         SB.Append('<sz val="' + Size + '"/>')
       else
@@ -1411,13 +1449,14 @@ begin
         const CellVAlign = TExcelVAlign(StrToIntDef(Parts[17], 0));
         const CellWrapText = Parts[18] = '1';
         const CellFontColor = StrToIntDef(Parts[19], 0);
+        const CellStrikeout = Parts[20] = '1';
 
         // Must match the FontKeys population format in the collection loop above,
         // field-for-field — this 5-vs-6-field mismatch was the original FontColor bug.
-        const FontKey = Format('%d|%d|%d|%s|%s|%d', [
-          Ord(IsBold), Ord(IsItalic), Ord(IsUnderline), CellFontName, CellFontSize, CellFontColor]);
+        const FontKey = Format('%d|%d|%d|%s|%s|%d|%d', [
+          Ord(IsBold), Ord(IsItalic), Ord(IsUnderline), CellFontName, CellFontSize, CellFontColor, Ord(CellStrikeout)]);
         var FontId := 0;
-        if FontKey <> '0|0|0|||0' then
+        if FontKey <> '0|0|0|||0|0' then
           FontId := 1 + FontKeys.IndexOf(FontKey);
 
         var FillId := 0;
@@ -1626,6 +1665,7 @@ begin
   FStyleFontSize.Clear;
   FStyleColors.Clear;
   FStyleFontColor.Clear;
+  FStyleStrikeout.Clear;
   FStyleBorderTopStyle.Clear;
   FStyleBorderTopColor.Clear;
   FStyleBorderRightStyle.Clear;
@@ -1642,6 +1682,7 @@ begin
   var FontsBold := TList<Boolean>.Create;
   var FontsItalic := TList<Boolean>.Create;
   var FontsUnderline := TList<Boolean>.Create;
+  var FontsStrikeout := TList<Boolean>.Create;
   var FontsName := TList<string>.Create;
   var FontsSize := TList<Double>.Create;
   var Fills := TList<Cardinal>.Create;
@@ -1670,6 +1711,7 @@ begin
       FontsBold.Add(Pos('<b/>', FontXml) > 0);
       FontsItalic.Add(Pos('<i/>', FontXml) > 0);
       FontsUnderline.Add(Pos('<u/>', FontXml) > 0);
+      FontsStrikeout.Add(Pos('<strike/>', FontXml) > 0);
 
       const ColorMatch = TRegEx.Match(FontXml, '<color\s+rgb="FF([0-9A-Fa-f]{6})"', [roIgnoreCase]);
       if ColorMatch.Success then
@@ -1834,6 +1876,8 @@ begin
           FColor := FontsColor[FontId];
         FStyleFontColor.Add(FColor);
 
+        FStyleStrikeout.Add((FontId < FontsStrikeout.Count) and (FontsStrikeout[FontId]));
+
         if BorderId < TopStyles.Count then
           FStyleBorderTopStyle.Add(TopStyles[BorderId])
         else
@@ -1906,6 +1950,7 @@ begin
     FontsSize.Free;
     FontsName.Free;
     FontsUnderline.Free;
+    FontsStrikeout.Free;
     FontsItalic.Free;
     FontsBold.Free;
   end;
@@ -2139,6 +2184,8 @@ begin
             Cell.FBackgroundColor := FStyleColors[StyleIdx];
           if (StyleIdx < FStyleFontColor.Count) and (FStyleFontColor[StyleIdx] <> 0) then
             Cell.FFontColor := FStyleFontColor[StyleIdx];
+          if (StyleIdx < FStyleStrikeout.Count) and (FStyleStrikeout[StyleIdx]) then
+            Cell.FStrikeout := True;
           if (StyleIdx < FStyleBorderTopStyle.Count) and (FStyleBorderTopStyle[StyleIdx] <> TExcelBorderStyle.None) then
             Cell.FBorderStyle[TExcelBorderSide.Top] := FStyleBorderTopStyle[StyleIdx];
           if (StyleIdx < FStyleBorderTopColor.Count) and (FStyleBorderTopColor[StyleIdx] <> 0) then
@@ -2195,6 +2242,8 @@ begin
           Cell.FBackgroundColor := FStyleColors[StyleIdx];
         if (StyleIdx < FStyleFontColor.Count) and (FStyleFontColor[StyleIdx] <> 0) then
           Cell.FFontColor := FStyleFontColor[StyleIdx];
+        if (StyleIdx < FStyleStrikeout.Count) and (FStyleStrikeout[StyleIdx]) then
+          Cell.FStrikeout := True;
         if (StyleIdx < FStyleBorderTopStyle.Count) and (FStyleBorderTopStyle[StyleIdx] <> TExcelBorderStyle.None) then
           Cell.FBorderStyle[TExcelBorderSide.Top] := FStyleBorderTopStyle[StyleIdx];
         if (StyleIdx < FStyleBorderTopColor.Count) and (FStyleBorderTopColor[StyleIdx] <> 0) then

--- a/Source/Excel/Office4D.Excel.pas
+++ b/Source/Excel/Office4D.Excel.pas
@@ -18,6 +18,8 @@ type
   // VeryHidden sheets can only be made visible again through code (or the VBA editor),
   // not through the Excel UI.
   TExcelSheetVisibility = (Visible, Hidden, VeryHidden);
+  TExcelFontStyle = (Bold, Italic, Underline, Strikeout);
+  TExcelFontStyles = set of TExcelFontStyle;
   {$SCOPEDENUMS OFF}
 
   IExcelCell = interface;
@@ -43,6 +45,8 @@ type
     procedure SetItalic(const Value: Boolean);
     function GetUnderline: Boolean;
     procedure SetUnderline(const Value: Boolean);
+    function GetStrikeout: Boolean;
+    procedure SetStrikeout(const Value: Boolean);
     function GetFontName: string;
     procedure SetFontName(const Value: string);
     function GetFontSize: Double;
@@ -63,6 +67,8 @@ type
     procedure SetWrapText(const Value: Boolean);
     function GetFontColor: Cardinal;
     procedure SetFontColor(const Value: Cardinal);
+    function GetFontStyle: TExcelFontStyles;
+    procedure SetFontStyle(const Value: TExcelFontStyles);
 
     property AsString: string read GetAsString write SetAsString;
     property AsFloat: Double read GetAsFloat write SetAsFloat;
@@ -73,6 +79,7 @@ type
     property Bold: Boolean read GetBold write SetBold;
     property Italic: Boolean read GetItalic write SetItalic;
     property Underline: Boolean read GetUnderline write SetUnderline;
+    property Strikeout: Boolean read GetStrikeout write SetStrikeout;
     property FontName: string read GetFontName write SetFontName;
     property FontSize: Double read GetFontSize write SetFontSize;
     property BackgroundColor: Cardinal read GetBackgroundColor write SetBackgroundColor;
@@ -83,6 +90,7 @@ type
     property VAlign: TExcelVAlign read GetVAlign write SetVAlign;
     property WrapText: Boolean read GetWrapText write SetWrapText;
     property FontColor: Cardinal read GetFontColor write SetFontColor;
+    property FontStyle: TExcelFontStyles read GetFontStyle write SetFontStyle;
   end;
 
   IExcelSheet = interface

--- a/Tests/Source/Office4D.Tests.Excel.FontStyle.pas
+++ b/Tests/Source/Office4D.Tests.Excel.FontStyle.pas
@@ -1,0 +1,237 @@
+unit Office4D.Tests.Excel.FontStyle;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelFontStyleTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FTempFile: string;
+
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure GetFontStyle_NoFormatting_ReturnsEmptySet;
+
+    [Test]
+    procedure SetFontStyle_BoldAndStrikeout_SetsUnderlyingProperties;
+
+    [Test]
+    procedure SetFontStyle_IsAFullReplace_ClearsStylesNotInTheNewSet;
+
+    [Test]
+    procedure SetBold_DirectlyThenReadFontStyle_ReflectsTheChange;
+
+    [Test]
+    procedure SetStrikeout_DirectlyThenReadFontStyle_ReflectsTheChange;
+
+    [Test]
+    procedure SaveToFile_WithStrikeout_ContainsStrikeElement;
+
+    [Test]
+    procedure RoundTrip_FontStyle_PreservesAllFourFlags;
+
+    [Test]
+    procedure RoundTrip_CombinedFontStyleAndFontColor_PreservesBoth;
+
+    [Test]
+    procedure SaveToFile_StrikeoutOnlyCell_ResolvesToDistinctFontEntry;
+  end;
+
+implementation
+
+uses
+  Office4D.Package;
+
+{ TExcelFontStyleTests }
+
+procedure TExcelFontStyleTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'fontstyle_test_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelFontStyleTests.TearDown;
+begin
+  FWorkbook := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TExcelFontStyleTests.GetFontStyle_NoFormatting_ReturnsEmptySet;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+
+  Assert.IsTrue(Cell.FontStyle = [], 'A cell with no formatting must report an empty FontStyle set');
+end;
+
+procedure TExcelFontStyleTests.SetFontStyle_BoldAndStrikeout_SetsUnderlyingProperties;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+
+  Cell.FontStyle := [TExcelFontStyle.Bold, TExcelFontStyle.Strikeout];
+
+  Assert.IsTrue(Cell.Bold, 'Bold property should reflect the FontStyle set');
+  Assert.IsFalse(Cell.Italic, 'Italic was not in the set and must stay False');
+  Assert.IsFalse(Cell.Underline, 'Underline was not in the set and must stay False');
+  Assert.IsTrue(TExcelFontStyle.Bold in Cell.FontStyle, 'Bold should read back from FontStyle');
+  Assert.IsTrue(TExcelFontStyle.Strikeout in Cell.FontStyle, 'Strikeout should read back from FontStyle');
+  Assert.IsFalse(TExcelFontStyle.Italic in Cell.FontStyle, 'Italic should not appear in FontStyle');
+end;
+
+procedure TExcelFontStyleTests.SetFontStyle_IsAFullReplace_ClearsStylesNotInTheNewSet;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+
+  // Establish Bold + Italic first via the existing per-flag properties.
+  Cell.Bold := True;
+  Cell.Italic := True;
+
+  // A FontStyle assignment that omits Bold and Italic must clear them, not merge with them --
+  // this is standard `set` assignment semantics, but worth asserting explicitly since it's
+  // easy to accidentally implement FontStyle's setter as an OR instead of a replace.
+  Cell.FontStyle := [TExcelFontStyle.Underline];
+
+  Assert.IsFalse(Cell.Bold, 'Bold must be cleared, not merged, by a FontStyle assignment that omits it');
+  Assert.IsFalse(Cell.Italic, 'Italic must be cleared, not merged, by a FontStyle assignment that omits it');
+  Assert.IsTrue(Cell.Underline, 'Underline should be set from the new FontStyle value');
+end;
+
+procedure TExcelFontStyleTests.SetBold_DirectlyThenReadFontStyle_ReflectsTheChange;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+
+  // FontStyle must be a live view over Bold/Italic/Underline/Strikeout, not separate
+  // storage that can desync from them.
+  Cell.Bold := True;
+
+  Assert.IsTrue(TExcelFontStyle.Bold in Cell.FontStyle,
+    'Setting Bold directly must be visible through FontStyle immediately, with no separate ' +
+    'FontStyle state to fall out of sync');
+end;
+
+procedure TExcelFontStyleTests.SetStrikeout_DirectlyThenReadFontStyle_ReflectsTheChange;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  const Cell = Sheet.Cell['A1'];
+
+  // Strikeout must behave exactly like Bold/Italic/Underline here -- it's a standalone
+  // property, not something only reachable through the FontStyle set.
+  Cell.Strikeout := True;
+
+  Assert.IsTrue(TExcelFontStyle.Strikeout in Cell.FontStyle,
+    'Setting Strikeout directly must be visible through FontStyle immediately');
+  Assert.IsTrue(Cell.Strikeout, 'The Strikeout property itself must read back True');
+end;
+
+procedure TExcelFontStyleTests.SaveToFile_WithStrikeout_ContainsStrikeElement;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Struck through';
+  Sheet.Cell['A1'].FontStyle := [TExcelFontStyle.Strikeout];
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    Assert.IsTrue(Pos('<strike/>', StylesXml) > 0, 'Should contain strike element in styles');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelFontStyleTests.RoundTrip_FontStyle_PreservesAllFourFlags;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Fully styled';
+  Sheet.Cell['A1'].FontStyle := [TExcelFontStyle.Bold, TExcelFontStyle.Italic,
+    TExcelFontStyle.Underline, TExcelFontStyle.Strikeout];
+  Sheet.Cell['B1'].AsString := 'Plain';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+
+  const CellA1 = Workbook2.Sheets[0].Cell['A1'];
+  Assert.IsTrue(CellA1.FontStyle = [TExcelFontStyle.Bold, TExcelFontStyle.Italic,
+    TExcelFontStyle.Underline, TExcelFontStyle.Strikeout], 'All four flags should survive round-trip');
+
+  const CellB1 = Workbook2.Sheets[0].Cell['B1'];
+  Assert.IsTrue(CellB1.FontStyle = [], 'Plain cell should round-trip with an empty FontStyle set');
+end;
+
+procedure TExcelFontStyleTests.RoundTrip_CombinedFontStyleAndFontColor_PreservesBoth;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Red and struck through';
+  Sheet.Cell['A1'].FontStyle := [TExcelFontStyle.Strikeout];
+  Sheet.Cell['A1'].FontColor := $FF0000;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Cell = Workbook2.Sheets[0].Cell['A1'];
+
+  Assert.IsTrue(TExcelFontStyle.Strikeout in Cell.FontStyle, 'Strikeout should survive alongside FontColor');
+  Assert.AreEqual(Cardinal($FF0000), Cell.FontColor, 'FontColor should survive alongside Strikeout');
+end;
+
+procedure TExcelFontStyleTests.SaveToFile_StrikeoutOnlyCell_ResolvesToDistinctFontEntry;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  // A1 has strikeout only; B1 has identical bold/italic/underline/color/size/name (all
+  // default) but no strikeout. If the FontKey field count/order ever drifts out of sync
+  // between the collection loop and the cellXfs reconstruction -- the exact class of bug
+  // that broke FontColor earlier -- these two would collapse onto the same font entry.
+  Sheet.Cell['A1'].FontStyle := [TExcelFontStyle.Strikeout];
+  Sheet.Cell['B1'].AsString := 'No strikeout';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    // Exactly one <strike/> should appear across the whole <fonts> block: the entry for
+    // A1's font. B1 uses the default font (index 0), which never gets a <strike/>.
+    var StrikeCount := 0;
+    var SearchPos := 1;
+    while True do
+    begin
+      const FoundPos = Pos('<strike/>', Copy(StylesXml, SearchPos, MaxInt));
+      if FoundPos = 0 then Break;
+      Inc(StrikeCount);
+      SearchPos := SearchPos + FoundPos + Length('<strike/>') - 1;
+    end;
+    Assert.AreEqual(1, StrikeCount, 'Exactly one font entry should carry <strike/>');
+  finally
+    Package.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelFontStyleTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -32,7 +32,8 @@ uses
   Office4D.Tests.Excel in 'Office4D.Tests.Excel.pas',
   Office4D.Tests.Excel.Write in 'Office4D.Tests.Excel.Write.pas',
   Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas',
-  Office4D.Tests.Excel.BorderSides in 'Office4D.Tests.Excel.BorderSides.pas';
+  Office4D.Tests.Excel.BorderSides in 'Office4D.Tests.Excel.BorderSides.pas',
+  Office4D.Tests.Excel.FontStyle in 'Office4D.Tests.Excel.FontStyle.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Source/Office4D.Tests.dproj
+++ b/Tests/Source/Office4D.Tests.dproj
@@ -165,6 +165,7 @@
         <DCCReference Include="Office4D.Tests.Excel.Write.pas"/>
         <DCCReference Include="Office4D.Tests.PowerPoint.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.BorderSides.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.FontStyle.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
I was missing a strikeout property, and a Cell.FontStyle property so that variations of bold, italics, underline and strikeout can be set at once. The FontStyle get/set the other properties, so no out of sync scenarios