### PR TITLE
Added FreezePanes function

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -98,8 +98,12 @@ type
     FRowHeights: TDictionary<Integer, Double>;
     FMergedRanges: TList<string>;
     FVisibility: TExcelSheetVisibility;
+    FFrozenRows: Integer;
+    FFrozenColumns: Integer;
 
     class function ColumnLetterToNumber(const Column: string): Integer; static;
+    class function ColumnNumberToLetters(const Column: Integer): string; static;
+    class procedure ParseCellAddress(const Address: string; out Col, Row: Integer); static;
   public
     constructor Create(const Name: string);
     destructor Destroy; override;
@@ -119,6 +123,11 @@ type
     function GetVisibility: TExcelSheetVisibility;
     procedure SetVisibility(const Value: TExcelSheetVisibility);
 
+    procedure FreezePanes(const TopLeftCell: string);
+    procedure UnfreezePanes;
+    function GetFrozenRows: Integer;
+    function GetFrozenColumns: Integer;
+
     procedure SetCellValue(const Address, Value: string; IsString: Boolean);
     procedure SetBooleanValue(const Address: string; Value: Boolean);
     procedure SetCellFormula(const Address, Formula, Value: string);
@@ -131,6 +140,8 @@ type
     property RowHeights: TDictionary<Integer, Double> read FRowHeights;
     property MergedRangesList: TList<string> read FMergedRanges;
     property Visibility: TExcelSheetVisibility read FVisibility write FVisibility;
+    property FrozenRows: Integer read GetFrozenRows;
+    property FrozenColumns: Integer read GetFrozenColumns;
   end;
 
   TExcelWorkbook = class(TInterfacedObject, IExcelWorkbook)
@@ -574,6 +585,33 @@ begin
   FVisibility := Value;
 end;
 
+procedure TExcelSheet.FreezePanes(const TopLeftCell: string);
+var
+  Col, Row: Integer;
+begin
+  ParseCellAddress(TopLeftCell, Col, Row);
+  // TopLeftCell is the first *unfrozen* (scrollable) cell -- e.g. 'C2' means columns
+  // A-B and row 1 are frozen, so the frozen counts are one less than the parsed position.
+  FFrozenColumns := Max(0, Col - 1);
+  FFrozenRows := Max(0, Row - 1);
+end;
+
+procedure TExcelSheet.UnfreezePanes;
+begin
+  FFrozenRows := 0;
+  FFrozenColumns := 0;
+end;
+
+function TExcelSheet.GetFrozenRows: Integer;
+begin
+  Result := FFrozenRows;
+end;
+
+function TExcelSheet.GetFrozenColumns: Integer;
+begin
+  Result := FFrozenColumns;
+end;
+
 class function TExcelSheet.ColumnLetterToNumber(const Column: string): Integer;
 begin
   Result := 0;
@@ -583,6 +621,35 @@ begin
     const CharVal = Ord(UpperColumn[CharIndex]) - Ord('A') + 1;
     Result := Result * 26 + CharVal;
   end;
+end;
+
+class function TExcelSheet.ColumnNumberToLetters(const Column: Integer): string;
+begin
+  Result := '';
+  var ColNum := Column;
+  while ColNum > 0 do
+  begin
+    const Remainder = (ColNum - 1) mod 26;
+    Result := Chr(Ord('A') + Remainder) + Result;
+    ColNum := (ColNum - 1) div 26;
+  end;
+end;
+
+class procedure TExcelSheet.ParseCellAddress(const Address: string; out Col, Row: Integer);
+begin
+  const UpperAddress = UpperCase(Trim(Address));
+  var ColPart := '';
+  var RowPart := '';
+  for var CharIndex := 1 to Length(UpperAddress) do
+    if CharInSet(UpperAddress[CharIndex], ['A'..'Z']) then
+      ColPart := ColPart + UpperAddress[CharIndex]
+    else
+      RowPart := RowPart + UpperAddress[CharIndex];
+
+  if (ColPart = '') or (RowPart = '') or not TryStrToInt(RowPart, Row) then
+    raise EExcelWorkbookException.CreateFmt('Invalid cell address: "%s"', [Address]);
+
+  Col := ColumnLetterToNumber(ColPart);
 end;
 
 procedure TExcelSheet.SetCellValue(const Address, Value: string; IsString: Boolean);
@@ -979,6 +1046,24 @@ begin
   try
     SB.Append(XmlDeclaration);
     SB.Append('<worksheet xmlns="' + SpreadsheetNs + '">');
+
+    const HasFrozenPanes = (Sheet.FrozenRows > 0) or (Sheet.FrozenColumns > 0);
+    if HasFrozenPanes then
+    begin
+      const TopLeftCell = TExcelSheet.ColumnNumberToLetters(Sheet.FrozenColumns + 1) + IntToStr(Sheet.FrozenRows + 1);
+      var ActivePane := 'topLeft';
+      if (Sheet.FrozenRows > 0) and (Sheet.FrozenColumns > 0) then
+        ActivePane := 'bottomRight'
+      else if Sheet.FrozenRows > 0 then
+        ActivePane := 'bottomLeft'
+      else if Sheet.FrozenColumns > 0 then
+        ActivePane := 'topRight';
+
+      SB.Append('<sheetViews><sheetView workbookViewId="0">');
+      SB.Append('<pane xSplit="' + IntToStr(Sheet.FrozenColumns) + '" ySplit="' + IntToStr(Sheet.FrozenRows) +
+        '" topLeftCell="' + TopLeftCell + '" activePane="' + ActivePane + '" state="frozen"/>');
+      SB.Append('</sheetView></sheetViews>');
+    end;
 
     const HasColumnWidths = (Sheet.ColumnWidths.Count > 0);
     if HasColumnWidths then
@@ -1993,15 +2078,7 @@ begin
     begin
       var ColNum := TExcelSheet.ColumnLetterToNumber(ColPart);
       Inc(ColNum, ColDelta);
-      // Convert column number back to letters
-      var ColLetters := '';
-      while ColNum > 0 do
-      begin
-        const Remainder = (ColNum - 1) mod 26;
-        ColLetters := Chr(Ord('A') + Remainder) + ColLetters;
-        ColNum := (ColNum - 1) div 26;
-      end;
-      NewColPart := ColLetters;
+      NewColPart := TExcelSheet.ColumnNumberToLetters(ColNum);
     end;
 
     if (NewColPart <> ColPart) or (NewRowPart <> RowPart) then
@@ -2019,6 +2096,20 @@ end;
 
 procedure TExcelWorkbook.ParseSheet(const Sheet: TExcelSheet; const Xml: string);
 begin
+  const PaneMatch = TRegEx.Match(Xml, '<pane\s+[^/]*/>', [roIgnoreCase]);
+  if PaneMatch.Success then
+  begin
+    const PaneXml = PaneMatch.Value;
+    const XSplitMatch = TRegEx.Match(PaneXml, 'xSplit="([^"]*)"', [roIgnoreCase]);
+    const YSplitMatch = TRegEx.Match(PaneXml, 'ySplit="([^"]*)"', [roIgnoreCase]);
+    // xSplit/ySplit are declared as xsd:double in the schema, though for a pure freeze
+    // (rather than an unfrozen split) they're always written as whole numbers in practice.
+    if XSplitMatch.Success then
+      Sheet.FFrozenColumns := Trunc(StrToFloatDef(XSplitMatch.Groups[1].Value, 0, TFormatSettings.Invariant));
+    if YSplitMatch.Success then
+      Sheet.FFrozenRows := Trunc(StrToFloatDef(YSplitMatch.Groups[1].Value, 0, TFormatSettings.Invariant));
+  end;
+
   const ColMatches = TRegEx.Matches(Xml, '<col\s[^/]*/>', [roIgnoreCase]);
   for var ColMatch in ColMatches do
   begin
@@ -2036,13 +2127,7 @@ begin
         const ColMax = StrToIntDef(MaxMatch.Groups[1].Value, 0);
         for var ColNum := ColMin to ColMax do
         begin
-          var ColLetters := '';
-          var N := ColNum;
-          while N > 0 do
-          begin
-            ColLetters := Chr(Ord('A') + (N - 1) mod 26) + ColLetters;
-            N := (N - 1) div 26;
-          end;
+          const ColLetters = TExcelSheet.ColumnNumberToLetters(ColNum);
           Sheet.SetColumnWidth(ColLetters, Width);
         end;
       end;

--- a/Source/Excel/Office4D.Excel.pas
+++ b/Source/Excel/Office4D.Excel.pas
@@ -110,12 +110,19 @@ type
     function GetVisibility: TExcelSheetVisibility;
     procedure SetVisibility(const Value: TExcelSheetVisibility);
 
+    procedure FreezePanes(const TopLeftCell: string);
+    procedure UnfreezePanes;
+    function GetFrozenRows: Integer;
+    function GetFrozenColumns: Integer;
+
     function GetCells: TDictionary<string, IExcelCell>;
 
     property Name: string read GetName;
     property Cell[const Address: string]: IExcelCell read GetCell;
     property Cells: TDictionary<string, IExcelCell> read GetCells;
     property Visibility: TExcelSheetVisibility read GetVisibility write SetVisibility;
+    property FrozenRows: Integer read GetFrozenRows;
+    property FrozenColumns: Integer read GetFrozenColumns;
   end;
 
   IExcelWorkbook = interface

--- a/Tests/Source/Office4D.Tests.Excel.FreezePanes.pas
+++ b/Tests/Source/Office4D.Tests.Excel.FreezePanes.pas
@@ -1,0 +1,277 @@
+unit Office4D.Tests.Excel.FreezePanes;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelFreezePanesTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FTempFile: string;
+
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure SaveToFile_NoFreeze_OmitsSheetViews;
+
+    [Test]
+    procedure FreezePanes_BothRowsAndColumns_SetsFrozenCounts;
+
+    [Test]
+    procedure FreezePanes_RowsOnly_LeavesColumnsAtZero;
+
+    [Test]
+    procedure FreezePanes_ColumnsOnly_LeavesRowsAtZero;
+
+    [Test]
+    procedure FreezePanes_TopLeftCorner_IsEquivalentToNoFreeze;
+
+    [Test]
+    procedure FreezePanes_InvalidAddress_RaisesException;
+
+    [Test]
+    procedure UnfreezePanes_AfterFreezing_ClearsFrozenState;
+
+    [Test]
+    procedure RoundTrip_FreezeBothRowsAndColumns_PreservesFrozenCounts;
+
+    [Test]
+    procedure SaveToFile_WithFreezePanes_ContainsCorrectPaneAttributes;
+
+    [Test]
+    procedure SaveToFile_FreezeRowsOnly_UsesBottomLeftActivePane;
+
+    [Test]
+    procedure SaveToFile_FreezeColumnsOnly_UsesTopRightActivePane;
+
+    [Test]
+    procedure SaveToFile_WithFreezePanesAndColumnWidths_SheetViewsPrecedesCols;
+  end;
+
+implementation
+
+uses
+  Office4D.Errors,
+  Office4D.Package;
+
+{ TExcelFreezePanesTests }
+
+procedure TExcelFreezePanesTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'freezepanes_test_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelFreezePanesTests.TearDown;
+begin
+  FWorkbook := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TExcelFreezePanesTests.SaveToFile_NoFreeze_OmitsSheetViews;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Test';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsFalse(Pos('<sheetViews>', SheetXml) > 0,
+      'A sheet with no frozen panes must not emit a sheetViews element at all');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelFreezePanesTests.FreezePanes_BothRowsAndColumns_SetsFrozenCounts;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.FreezePanes('C2');
+
+  Assert.AreEqual(1, Sheet.FrozenRows, 'Row 1 should be frozen (topLeftCell row - 1)');
+  Assert.AreEqual(2, Sheet.FrozenColumns, 'Columns A and B should be frozen (topLeftCell col - 1)');
+end;
+
+procedure TExcelFreezePanesTests.FreezePanes_RowsOnly_LeavesColumnsAtZero;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.FreezePanes('A2');
+
+  Assert.AreEqual(1, Sheet.FrozenRows, 'Row 1 should be frozen');
+  Assert.AreEqual(0, Sheet.FrozenColumns, 'No columns should be frozen');
+end;
+
+procedure TExcelFreezePanesTests.FreezePanes_ColumnsOnly_LeavesRowsAtZero;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.FreezePanes('B1');
+
+  Assert.AreEqual(0, Sheet.FrozenRows, 'No rows should be frozen');
+  Assert.AreEqual(1, Sheet.FrozenColumns, 'Column A should be frozen');
+end;
+
+procedure TExcelFreezePanesTests.FreezePanes_TopLeftCorner_IsEquivalentToNoFreeze;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  // Freezing at A1 (the top-left corner itself) has nothing above/left of it to freeze --
+  // this matches Excel's own UI, where selecting A1 and choosing "Freeze Panes" is a no-op.
+  Sheet.FreezePanes('A1');
+
+  Assert.AreEqual(0, Sheet.FrozenRows);
+  Assert.AreEqual(0, Sheet.FrozenColumns);
+end;
+
+procedure TExcelFreezePanesTests.FreezePanes_InvalidAddress_RaisesException;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  Assert.WillRaise(
+    procedure
+    begin
+      Sheet.FreezePanes('NotACell');
+    end,
+    EExcelWorkbookException,
+    'An unparseable cell address must raise rather than silently freezing nothing or defaulting'
+  );
+end;
+
+procedure TExcelFreezePanesTests.UnfreezePanes_AfterFreezing_ClearsFrozenState;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.FreezePanes('C2');
+  Sheet.UnfreezePanes;
+
+  Assert.AreEqual(0, Sheet.FrozenRows);
+  Assert.AreEqual(0, Sheet.FrozenColumns);
+end;
+
+procedure TExcelFreezePanesTests.RoundTrip_FreezeBothRowsAndColumns_PreservesFrozenCounts;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Header';
+  Sheet.FreezePanes('C2');
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  const Sheet2 = Workbook2.Sheets[0];
+
+  Assert.AreEqual(1, Sheet2.FrozenRows, 'Frozen row count should survive round-trip');
+  Assert.AreEqual(2, Sheet2.FrozenColumns, 'Frozen column count should survive round-trip');
+end;
+
+procedure TExcelFreezePanesTests.SaveToFile_WithFreezePanesAndColumnWidths_SheetViewsPrecedesCols;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Test';
+  Sheet.FreezePanes('B2');
+  Sheet.SetColumnWidth('A', 20);
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    const SheetViewsPos = Pos('<sheetViews>', SheetXml);
+    const ColsPos = Pos('<cols>', SheetXml);
+
+    Assert.IsTrue(SheetViewsPos > 0, 'sheetViews element should be present');
+    Assert.IsTrue(ColsPos > 0, 'cols element should be present');
+    // OOXML's schema is order-sensitive here -- sheetViews must precede cols, or the
+    // file can render incorrectly (or not open) in strict readers even though it's
+    // well-formed XML. This ordering bug has bitten other libraries in exactly this spot.
+    Assert.IsTrue(SheetViewsPos < ColsPos, 'sheetViews must be written before cols in the worksheet XML');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelFreezePanesTests.SaveToFile_WithFreezePanes_ContainsCorrectPaneAttributes;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Test';
+  Sheet.FreezePanes('C2');
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsTrue(Pos('xSplit="2"', SheetXml) > 0, 'xSplit should equal the frozen column count');
+    Assert.IsTrue(Pos('ySplit="1"', SheetXml) > 0, 'ySplit should equal the frozen row count');
+    Assert.IsTrue(Pos('topLeftCell="C2"', SheetXml) > 0, 'topLeftCell should be the first scrollable cell');
+    Assert.IsTrue(Pos('state="frozen"', SheetXml) > 0, 'state should be frozen, not split');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelFreezePanesTests.SaveToFile_FreezeRowsOnly_UsesBottomLeftActivePane;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Test';
+  Sheet.FreezePanes('A2'); // rows only
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    // Freezing rows only puts the active pane at bottom-left, not bottom-right -- getting
+    // this wrong doesn't corrupt the file, but the scroll/selection behavior around the
+    // freeze boundary misbehaves in Excel.
+    Assert.IsTrue(Pos('activePane="bottomLeft"', SheetXml) > 0,
+      'Row-only freeze must use activePane="bottomLeft"');
+    Assert.IsFalse(Pos('activePane="bottomRight"', SheetXml) > 0,
+      'Row-only freeze must not use the both-axes activePane value');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelFreezePanesTests.SaveToFile_FreezeColumnsOnly_UsesTopRightActivePane;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsString := 'Test';
+  Sheet.FreezePanes('B1'); // columns only
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SheetXml = Package.GetPartContent('xl/worksheets/sheet1.xml');
+    Assert.IsTrue(Pos('activePane="topRight"', SheetXml) > 0,
+      'Column-only freeze must use activePane="topRight"');
+    Assert.IsFalse(Pos('activePane="bottomRight"', SheetXml) > 0,
+      'Column-only freeze must not use the both-axes activePane value');
+  finally
+    Package.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelFreezePanesTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -33,7 +33,8 @@ uses
   Office4D.Tests.Excel.Write in 'Office4D.Tests.Excel.Write.pas',
   Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas',
   Office4D.Tests.Excel.BorderSides in 'Office4D.Tests.Excel.BorderSides.pas',
-  Office4D.Tests.Excel.FontStyle in 'Office4D.Tests.Excel.FontStyle.pas';
+  Office4D.Tests.Excel.FontStyle in 'Office4D.Tests.Excel.FontStyle.pas',
+  Office4D.Tests.Excel.FreezePanes in 'Office4D.Tests.Excel.FreezePanes.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Source/Office4D.Tests.dproj
+++ b/Tests/Source/Office4D.Tests.dproj
@@ -166,6 +166,7 @@
         <DCCReference Include="Office4D.Tests.PowerPoint.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.BorderSides.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.FontStyle.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.FreezePanes.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
FreezePanes procedure follows library's addressing idiom - and an ambiguous UnfreezePanes procedure added as well - but identical functional wise to Sheet.FreezePanes('A1') - clearing the freeze like Excel UI would. 