### PR TITLE
Preserve number formats on load/save round-trip

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -152,6 +152,7 @@ type
     FStyleVAlign: TList<TExcelVAlign>;
     FStyleWrapText: TList<Boolean>;
     FStyleIsDate: TList<Boolean>;
+    FStyleNumberFormat: TList<string>;
 
     procedure ParseWorkbook(const Xml: string);
     procedure ParseSharedStrings(const Xml: string);
@@ -614,10 +615,12 @@ begin
   FStyleVAlign := TList<TExcelVAlign>.Create;
   FStyleWrapText := TList<Boolean>.Create;
   FStyleIsDate := TList<Boolean>.Create;
+  FStyleNumberFormat := TList<string>.Create;
 end;
 
 destructor TExcelWorkbook.Destroy;
 begin
+  FStyleNumberFormat.Free;
   FStyleIsDate.Free;
   FStyleWrapText.Free;
   FStyleVAlign.Free;
@@ -1592,6 +1595,33 @@ procedure TExcelWorkbook.ParseStyles(const Xml: string);
               ((NumFmtId >= 45) and (NumFmtId <= 47));
   end;
 
+  // Format codes for the non-date built-in numFmtIds (ECMA-376 part 1,
+  // section 18.8.30). Files authored by Excel reference these by id only,
+  // without a <numFmt> element, so the codes have to be supplied here to
+  // survive a round-trip (they are re-emitted as custom formats on save).
+  function BuiltInFormatCode(const NumFmtId: Integer): string;
+  begin
+    case NumFmtId of
+      1: Result := '0';
+      2: Result := '0.00';
+      3: Result := '#,##0';
+      4: Result := '#,##0.00';
+      9: Result := '0%';
+      10: Result := '0.00%';
+      11: Result := '0.00E+00';
+      12: Result := '# ?/?';
+      13: Result := '# ??/??';
+      37: Result := '#,##0 ;(#,##0)';
+      38: Result := '#,##0 ;[Red](#,##0)';
+      39: Result := '#,##0.00;(#,##0.00)';
+      40: Result := '#,##0.00;[Red](#,##0.00)';
+      48: Result := '##0.0E+0';
+      49: Result := '@';
+    else
+      Result := '';
+    end;
+  end;
+
   // Heuristic used to classify a custom (non-built-in) format code, e.g.
   // "yyyy-mm-dd" or "dd/mm/yyyy hh:mm". Quoted literal text and bracketed
   // sections (colour tags like [Red], locale tags like [$-409], or
@@ -1638,6 +1668,7 @@ begin
   FStyleVAlign.Clear;
   FStyleWrapText.Clear;
   FStyleIsDate.Clear;
+  FStyleNumberFormat.Clear;
 
   var FontsBold := TList<Boolean>.Create;
   var FontsItalic := TList<Boolean>.Create;
@@ -1787,11 +1818,22 @@ begin
 
         var CustomFormatCode: string;
         if IsBuiltInDateNumFmtId(NumFmtId) then
-          FStyleIsDate.Add(True)
+        begin
+          // Built-in date formats are re-emitted as numFmtId 14/22 on save,
+          // so no format code needs to be carried on the cell.
+          FStyleIsDate.Add(True);
+          FStyleNumberFormat.Add('');
+        end
         else if CustomNumFmts.TryGetValue(NumFmtId, CustomFormatCode) then
-          FStyleIsDate.Add(IsDateFormatCode(CustomFormatCode))
+        begin
+          FStyleIsDate.Add(IsDateFormatCode(CustomFormatCode));
+          FStyleNumberFormat.Add(CustomFormatCode);
+        end
         else
+        begin
           FStyleIsDate.Add(False);
+          FStyleNumberFormat.Add(BuiltInFormatCode(NumFmtId));
+        end;
 
         const FontIdMatch = TRegEx.Match(XfXml, 'fontId="(\d+)"', [roIgnoreCase]);
         var FontId := 0;
@@ -2161,6 +2203,8 @@ begin
             Cell.FVAlign := FStyleVAlign[StyleIdx];
           if (StyleIdx < FStyleWrapText.Count) and (FStyleWrapText[StyleIdx]) then
             Cell.FWrapText := True;
+          if (StyleIdx < FStyleNumberFormat.Count) and (FStyleNumberFormat[StyleIdx] <> '') then
+            Cell.FNumberFormat := FStyleNumberFormat[StyleIdx];
         end;
       end;
     end;
@@ -2217,6 +2261,8 @@ begin
           Cell.FVAlign := FStyleVAlign[StyleIdx];
         if (StyleIdx < FStyleWrapText.Count) and (FStyleWrapText[StyleIdx]) then
           Cell.FWrapText := True;
+        if (StyleIdx < FStyleNumberFormat.Count) and (FStyleNumberFormat[StyleIdx] <> '') then
+          Cell.FNumberFormat := FStyleNumberFormat[StyleIdx];
       end;
     end;
 

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -209,6 +209,15 @@ type
 
     [Test]
     procedure SaveToFile_AllSheetsHidden_RaisesException;
+
+    [Test]
+    procedure RoundTrip_CustomNumberFormat_PreservesFormat;
+
+    [Test]
+    procedure RoundTrip_CustomDateFormat_PreservesFormat;
+
+    [Test]
+    procedure LoadFromFile_ExcelAuthoredNumberFormats_ArePreserved;
   end;
 
 implementation
@@ -1288,6 +1297,102 @@ begin
     end,
     EExcelWorkbookException
   );
+end;
+
+procedure TExcelWriteTests.RoundTrip_CustomNumberFormat_PreservesFormat;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 1.5;
+  Sheet.Cell['A1'].NumberFormat := '0.000';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual('0.000', Workbook2.Sheets[0].Cell['A1'].NumberFormat, 'Custom number format should survive a load');
+
+  // Save the reloaded workbook again: the format must also survive a full
+  // load-save cycle, not just live on the in-memory cell.
+  Workbook2.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const StylesXml = Package.GetPartContent('xl/styles.xml');
+    Assert.IsTrue(Pos('formatCode="0.000"', StylesXml) > 0, 'Resaved styles.xml should still contain the custom format');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.RoundTrip_CustomDateFormat_PreservesFormat;
+begin
+  const TestValue = EncodeDate(2024, 6, 15) + EncodeTime(14, 30, 0, 0);
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsDateTime := TestValue;
+  Sheet.Cell['A1'].NumberFormat := 'dd.mm.yyyy hh:mm';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual('dd.mm.yyyy hh:mm', Workbook2.Sheets[0].Cell['A1'].NumberFormat, 'Custom date format should survive a load');
+  Assert.AreEqual(Double(TestValue), Double(Workbook2.Sheets[0].Cell['A1'].AsDateTime), 1E-8, 'Date value should be preserved');
+end;
+
+procedure TExcelWriteTests.LoadFromFile_ExcelAuthoredNumberFormats_ArePreserved;
+
+  procedure AddPart(const Zip: TZipFile; const PartName, Content: string);
+  begin
+    Zip.Add(TEncoding.UTF8.GetBytes(Content), PartName);
+  end;
+
+const
+  SpreadsheetNs = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+  OfficeDocRelsNs = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+begin
+  // Excel-authored files reference built-in formats (like 9 = "0%") by id only
+  // and start custom numFmt ids at 164, one below the 165 this library uses,
+  // so this file cannot be produced through the library's own save path.
+  const SourceFile = TPath.Combine(TPath.GetTempPath, 'excel_authored_' + TGUID.NewGuid.ToString + '.xlsx');
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(SourceFile, zmWrite);
+    AddPart(Zip, 'xl/workbook.xml',
+      '<workbook xmlns="' + SpreadsheetNs + '" xmlns:r="' + OfficeDocRelsNs + '">' +
+      '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>');
+    AddPart(Zip, 'xl/styles.xml',
+      '<styleSheet xmlns="' + SpreadsheetNs + '">' +
+      '<numFmts count="1"><numFmt numFmtId="164" formatCode="0.000"/></numFmts>' +
+      '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+      '<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>' +
+      '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+      '<cellXfs count="3">' +
+      '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+      '<xf numFmtId="164" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>' +
+      '<xf numFmtId="9" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>' +
+      '</cellXfs></styleSheet>');
+    AddPart(Zip, 'xl/worksheets/sheet1.xml',
+      '<worksheet xmlns="' + SpreadsheetNs + '"><sheetData>' +
+      '<row r="1"><c r="A1" s="1"><v>1.5</v></c><c r="B1" s="2"><v>0.25</v></c></row>' +
+      '</sheetData></worksheet>');
+    Zip.Close;
+
+    FWorkbook.LoadFromFile(SourceFile);
+    Assert.AreEqual('0.000', FWorkbook.Sheets[0].Cell['A1'].NumberFormat, 'Custom numFmt 164 should be applied to the cell');
+    Assert.AreEqual('0%', FWorkbook.Sheets[0].Cell['B1'].NumberFormat, 'Built-in numFmt 9 should map to its format code');
+
+    FWorkbook.SaveToFile(FTempFile);
+
+    const Workbook2 = TExcelWorkbookFactory.Create;
+    Workbook2.LoadFromFile(FTempFile);
+    Assert.AreEqual('0.000', Workbook2.Sheets[0].Cell['A1'].NumberFormat, 'Custom format should survive a resave');
+    Assert.AreEqual('0%', Workbook2.Sheets[0].Cell['B1'].NumberFormat, 'Built-in format should survive a resave');
+  finally
+    Zip.Free;
+    if TFile.Exists(SourceFile) then
+      TFile.Delete(SourceFile);
+  end;
 end;
 
 initialization


### PR DESCRIPTION
## Problem

Loading an existing .xlsx and saving it silently dropped all number formats:

- `ParseStyles` read custom `<numFmt>` entries but only kept a date-or-not
  boolean per cell style (`FStyleIsDate`); the actual format code was discarded
  and never applied to cells.
- Since `GenerateStyles` only emits formats present in `IExcelCell.NumberFormat`,
  a load/save round-trip stripped the `<numFmts>` block, and affected cells fell
  back to Excel's *General* format (wrong decimal count, no thousand separator).

Formats set explicitly through the API were unaffected; only formats read from
file were lost.

## Fix

- New `FStyleNumberFormat` list in `TExcelWorkbook`, filled per `<xf>` in
  `ParseStyles` alongside the existing per-style lists.
- Both style-application sites in `ParseSheet` (value cells and self-closing
  styled empty cells) now copy the format code onto the cell, the same way
  bold/fill/alignment are applied, so `GenerateStyles` re-emits it on save.
- Built-in non-date format ids (1-4, 9-13, 37-40, 48, 49) are mapped to their
  ECMA-376 §18.8.30 format codes via a new `BuiltInFormatCode` lookup. Files
  authored by Excel reference these by id only (e.g. `numFmtId="9"` for `0%`)
  with no `<numFmt>` element, so without the mapping they would still be lost.
  On save they are re-emitted as custom formats (id 165+), which renders
  identically.
- Built-in date formats (ids 14-22, 45-47) intentionally carry no format code
  and keep round-tripping via `numFmtId` 14/22, as before.

## Out of scope

Whole-column/row formatting and named cell styles are not modelled by the
library; cells that only inherit a format from those still need an explicit
`NumberFormat` when written through the API.

## Tests

- `RoundTrip_CustomNumberFormat_PreservesFormat` — custom format survives
  save/load/resave, including in the regenerated styles.xml.
- `RoundTrip_CustomDateFormat_PreservesFormat` — custom date format and value
  survive.
- `LoadFromFile_ExcelAuthoredNumberFormats_ArePreserved` — hand-built xlsx with
  a custom id 164 and built-in id 9 (both unproducible through the library's
  own save path), loaded and resaved.

All 233 tests pass; the 3 new tests fail without the library fix.