### PR TITLE
feat: add sheet removal and column/row clear & delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,40 @@ begin
 end;
 ```
 
+### Editing Sheets, Columns and Rows
+
+```pascal
+uses
+  Office4D.Excel;
+
+var
+  Workbook: IExcelWorkbook;
+  Sheet: IExcelSheet;
+begin
+  Workbook := TExcelWorkbookFactory.Create;
+  Workbook.LoadFromFile('report.xlsx');
+
+  // Remove a whole sheet (by index or by name)
+  Workbook.RemoveSheetByName('Scratch');
+
+  Sheet := Workbook.SheetByName('Data');
+
+  // Clear a column or row: removes cell contents and styling, but leaves the
+  // structure (column widths, row heights, merged ranges) in place.
+  Sheet.ClearColumn('D');
+  Sheet.ClearRow(5);
+
+  // Delete a column or row: everything past it shifts back by one. Column widths,
+  // row heights, merged ranges and frozen panes move with it, and every formula
+  // reference is rewritten (absolute refs and ranges included). A reference to a
+  // deleted line becomes #REF!, exactly as Excel does.
+  Sheet.DeleteColumn('C');
+  Sheet.DeleteRow(2);
+
+  Workbook.SaveToFile('report.xlsx');
+end;
+```
+
 ### Stream Support
 
 Both Word and Excel support stream-based I/O:
@@ -271,12 +305,16 @@ Examples/      - Demo application
 
 - Multiple worksheets
 - Sheet visibility (visible, hidden, very hidden)
+- Add and remove sheets
+- Clear a column or row (contents only, structure preserved)
+- Delete a column or row with reflow and formula-reference rewriting (#REF! on deleted lines)
 - Cell data types: string, number, boolean, datetime
 - Cell styling: bold, background color
 - Number formats (currency, percentage, custom)
 - Formulas with calculated values
 - Column widths
 - Merged cells
+- Freeze panes
 - Shared strings optimization
 - Metadata (author, title, dates)
 

--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -18,6 +18,8 @@ type
   TCellType = (Empty, StringValue, Number, Boolean, DateTime);
   {$SCOPEDENUMS OFF}
 
+  TExcelWorkbook = class;
+
   TExcelCell = class(TInterfacedObject, IExcelCell)
   private
     FStringValue: string;
@@ -100,10 +102,15 @@ type
     FVisibility: TExcelSheetVisibility;
     FFrozenRows: Integer;
     FFrozenColumns: Integer;
+    FOwner: TExcelWorkbook;
 
     class function ColumnLetterToNumber(const Column: string): Integer; static;
     class function ColumnNumberToLetters(const Column: Integer): string; static;
     class procedure ParseCellAddress(const Address: string; out Col, Row: Integer); static;
+
+    procedure ClearLine(const AIsColumn: Boolean; const AIndex: Integer);
+    procedure DeleteLine(const AIsColumn: Boolean; const AIndex: Integer);
+    procedure RewriteOwnFormulas(const AIsColumn: Boolean; const AIndex: Integer);
   public
     constructor Create(const Name: string);
     destructor Destroy; override;
@@ -127,6 +134,11 @@ type
     procedure UnfreezePanes;
     function GetFrozenRows: Integer;
     function GetFrozenColumns: Integer;
+
+    procedure ClearColumn(const Column: string);
+    procedure ClearRow(const Row: Integer);
+    procedure DeleteColumn(const Column: string);
+    procedure DeleteRow(const Row: Integer);
 
     procedure SetCellValue(const Address, Value: string; IsString: Boolean);
     procedure SetBooleanValue(const Address: string; Value: Boolean);
@@ -188,6 +200,8 @@ type
     function BuildStyleMap: TDictionary<string, Integer>;
     function GetStyleKey(const Cell: TExcelCell): string;
     function GetCellStyleIndex(const Cell: TExcelCell; const StyleMap: TDictionary<string, Integer>): Integer;
+
+    procedure ApplyFormulaDelete(const ATargetSheet: TExcelSheet; const AIsColumn: Boolean; const ALineIndex: Integer);
   public
     constructor Create;
     destructor Destroy; override;
@@ -204,6 +218,9 @@ type
 
     function AddSheet(const Name: string): IExcelSheet;
     function SheetByName(const Name: string): IExcelSheet;
+
+    procedure RemoveSheet(Index: Integer);
+    procedure RemoveSheetByName(const Name: string);
   end;
 
 implementation
@@ -243,6 +260,247 @@ const
   PartWorkbookRels = 'xl/_rels/workbook.xml.rels';
   PartSheetPrefix = 'xl/worksheets/sheet';
   PartSheetSuffix = '.xml';
+
+{ Formula reference rewriting for DeleteColumn / DeleteRow }
+
+// Left edge of a reference range on the deleted axis. A coordinate before the
+// deleted line stays put; one after it shifts down by one; one exactly on the
+// deleted line clamps to the deleted position (the next surviving line moves there).
+function ClampLo(const AValue, ADeletedIndex: Integer): Integer;
+begin
+  if AValue < ADeletedIndex then
+    Result := AValue
+  else if AValue > ADeletedIndex then
+    Result := AValue - 1
+  else
+    Result := ADeletedIndex;
+end;
+
+// Right edge of a reference range on the deleted axis. Identical to ClampLo except
+// a coordinate exactly on the deleted line clamps to the line just before it, so a
+// range whose far edge sat on the deleted line shrinks (e.g. A1:C1 -> A1:B1).
+function ClampHi(const AValue, ADeletedIndex: Integer): Integer;
+begin
+  if AValue < ADeletedIndex then
+    Result := AValue
+  else if AValue > ADeletedIndex then
+    Result := AValue - 1
+  else
+    Result := ADeletedIndex - 1;
+end;
+
+// Splits an optional leading '$' from a column/row part, e.g. '$D' -> ('D', True).
+function SplitDollar(const APart: string; out AIsAbsolute: Boolean): string;
+begin
+  AIsAbsolute := APart.StartsWith('$');
+  if AIsAbsolute then
+    Result := APart.Substring(1)
+  else
+    Result := APart;
+end;
+
+function DollarIf(const AIsAbsolute: Boolean): string;
+begin
+  if AIsAbsolute then
+    Result := '$'
+  else
+    Result := '';
+end;
+
+// Turns a matched sheet prefix (including the trailing '!', possibly quoted) into
+// the bare sheet name, e.g. '''My Sheet''!' -> 'My Sheet'.
+function UnquoteSheetPrefix(const APrefix: string): string;
+begin
+  Result := APrefix;
+  if Result.EndsWith('!') then
+    Result := Result.Substring(0, Result.Length - 1);
+  if Result.StartsWith('''') and Result.EndsWith('''') and (Result.Length >= 2) then
+  begin
+    Result := Result.Substring(1, Result.Length - 2);
+    Result := StringReplace(Result, '''''', '''', [rfReplaceAll]);
+  end;
+end;
+
+// Rewrites a single matched cell reference or range for a column/row deletion.
+// References that do not resolve to the deleted sheet are returned verbatim.
+// Group layout: 1=sheet prefix, 2=col1, 3=row1, 4=col2, 5=row2 (4/5 only on a range).
+function TransformRefMatch(const AMatch: TMatch; const ATargetSheet, AFormulaSheet: string;
+  const AIsColumn: Boolean; const ALineIndex: Integer): string;
+
+  // Delphi's TMatch only reports groups up to the highest one that participated, so an
+  // optional trailing group is absent (not merely unsuccessful) on a non-range match.
+  function GroupValue(const AIndex: Integer): string;
+  begin
+    if AIndex < AMatch.Groups.Count then
+      Result := AMatch.Groups[AIndex].Value
+    else
+      Result := '';
+  end;
+
+  function GroupSuccess(const AIndex: Integer): Boolean;
+  begin
+    Result := (AIndex < AMatch.Groups.Count) and AMatch.Groups[AIndex].Success;
+  end;
+
+begin
+  const Prefix1 = GroupValue(1);
+  const IsRange = GroupSuccess(5);
+
+  var RefSheet := AFormulaSheet;
+  if Prefix1 <> '' then
+    RefSheet := UnquoteSheetPrefix(Prefix1);
+
+  // Only references pointing at the sheet whose line was deleted are affected.
+  if not SameText(RefSheet, ATargetSheet) then
+    Exit(AMatch.Value);
+
+  var Col1Abs, Row1Abs: Boolean;
+  const Col1Letters = SplitDollar(GroupValue(2), Col1Abs);
+  const Row1Digits = SplitDollar(GroupValue(3), Row1Abs);
+  var Col1 := TExcelSheet.ColumnLetterToNumber(Col1Letters);
+  var Row1 := StrToIntDef(Row1Digits, 0);
+
+  var Col2Abs := Col1Abs;
+  var Row2Abs := Row1Abs;
+  var Col2 := Col1;
+  var Row2 := Row1;
+  if IsRange then
+  begin
+    Col2 := TExcelSheet.ColumnLetterToNumber(SplitDollar(GroupValue(4), Col2Abs));
+    Row2 := StrToIntDef(SplitDollar(GroupValue(5), Row2Abs), 0);
+  end;
+
+  if AIsColumn then
+  begin
+    const Lo = Min(Col1, Col2);
+    const Hi = Max(Col1, Col2);
+    if (Lo = ALineIndex) and (Hi = ALineIndex) then
+      Exit('#REF!');
+    const NewLo = ClampLo(Lo, ALineIndex);
+    const NewHi = ClampHi(Hi, ALineIndex);
+    if Col1 <= Col2 then
+    begin
+      Col1 := NewLo;
+      Col2 := NewHi;
+    end
+    else
+    begin
+      Col1 := NewHi;
+      Col2 := NewLo;
+    end;
+  end
+  else
+  begin
+    const Lo = Min(Row1, Row2);
+    const Hi = Max(Row1, Row2);
+    if (Lo = ALineIndex) and (Hi = ALineIndex) then
+      Exit('#REF!');
+    const NewLo = ClampLo(Lo, ALineIndex);
+    const NewHi = ClampHi(Hi, ALineIndex);
+    if Row1 <= Row2 then
+    begin
+      Row1 := NewLo;
+      Row2 := NewHi;
+    end
+    else
+    begin
+      Row1 := NewHi;
+      Row2 := NewLo;
+    end;
+  end;
+
+  Result := Prefix1 + DollarIf(Col1Abs) + TExcelSheet.ColumnNumberToLetters(Col1) +
+    DollarIf(Row1Abs) + IntToStr(Row1);
+  if IsRange then
+    Result := Result + ':' + DollarIf(Col2Abs) + TExcelSheet.ColumnNumberToLetters(Col2) +
+      DollarIf(Row2Abs) + IntToStr(Row2);
+end;
+
+// Applies the reference transform to a stretch of formula text that contains no
+// string literals.
+function TransformFormulaSegment(const ASegment, ATargetSheet, AFormulaSheet: string;
+  const AIsColumn: Boolean; const ALineIndex: Integer): string;
+const
+  // [not a name char] [optional sheet prefix] col row  [ ':' [prefix] col row ]  [not '(' or name char].
+  // The trailing '(' guard keeps function names like LOG10 from being read as a reference.
+  // Groups: 1=sheet prefix, 2=col1, 3=row1, 4=col2, 5=row2. The second endpoint's sheet
+  // prefix (rare) is matched but not captured.
+  RefPattern =
+    '(?<![A-Za-z0-9_])' +
+    '((?:''[^'']*''|[A-Za-z_][A-Za-z0-9_.]*)!)?' +
+    '(\$?[A-Za-z]{1,3})(\$?\d+)' +
+    '(?::(?:(?:''[^'']*''|[A-Za-z_][A-Za-z0-9_.]*)!)?(\$?[A-Za-z]{1,3})(\$?\d+))?' +
+    '(?![A-Za-z0-9_(])';
+begin
+  Result := ASegment;
+  const Matches = TRegEx.Matches(ASegment, RefPattern, [roIgnoreCase]);
+  var OffsetAdjust := 0;
+  for var M in Matches do
+  begin
+    const OldRef = M.Value;
+    const NewRef = TransformRefMatch(M, ATargetSheet, AFormulaSheet, AIsColumn, ALineIndex);
+    if NewRef <> OldRef then
+    begin
+      const RefPos = M.Index + OffsetAdjust; // TMatch.Index is 1-based (Delphi string convention)
+      Delete(Result, RefPos, Length(OldRef));
+      Insert(NewRef, Result, RefPos);
+      Inc(OffsetAdjust, Length(NewRef) - Length(OldRef));
+    end;
+  end;
+end;
+
+// Rewrites all cell references in a formula for a column/row deletion on ATargetSheet.
+// String literals inside the formula are copied verbatim so cell-like text is never touched.
+function TransformFormulaForLineDelete(const AFormula, ATargetSheet, AFormulaSheet: string;
+  const AIsColumn: Boolean; const ALineIndex: Integer): string;
+begin
+  var Output := TStringBuilder.Create;
+  var Segment := TStringBuilder.Create;
+  try
+    var CharIndex := 1;
+    while CharIndex <= Length(AFormula) do
+    begin
+      if AFormula[CharIndex] = '"' then
+      begin
+        if Segment.Length > 0 then
+        begin
+          Output.Append(TransformFormulaSegment(Segment.ToString, ATargetSheet, AFormulaSheet, AIsColumn, ALineIndex));
+          Segment.Clear;
+        end;
+        // Copy the literal verbatim, treating a doubled "" as an escaped quote.
+        Output.Append(AFormula[CharIndex]);
+        Inc(CharIndex);
+        while CharIndex <= Length(AFormula) do
+        begin
+          Output.Append(AFormula[CharIndex]);
+          if AFormula[CharIndex] = '"' then
+          begin
+            if (CharIndex < Length(AFormula)) and (AFormula[CharIndex + 1] = '"') then
+            begin
+              Output.Append(AFormula[CharIndex + 1]);
+              Inc(CharIndex, 2);
+              Continue;
+            end;
+            Inc(CharIndex);
+            Break;
+          end;
+          Inc(CharIndex);
+        end;
+      end
+      else
+      begin
+        Segment.Append(AFormula[CharIndex]);
+        Inc(CharIndex);
+      end;
+    end;
+    if Segment.Length > 0 then
+      Output.Append(TransformFormulaSegment(Segment.ToString, ATargetSheet, AFormulaSheet, AIsColumn, ALineIndex));
+    Result := Output.ToString;
+  finally
+    Segment.Free;
+    Output.Free;
+  end;
+end;
 
 { TExcelCell }
 
@@ -686,6 +944,172 @@ begin
   Cell.FFormula := Formula;
   Cell.SetAsFloat(StrToFloatDef(Value, 0, TFormatSettings.Invariant));
   Cell.FStringValue := Value;
+end;
+
+procedure TExcelSheet.ClearColumn(const Column: string);
+begin
+  ClearLine(True, ColumnLetterToNumber(Column));
+end;
+
+procedure TExcelSheet.ClearRow(const Row: Integer);
+begin
+  ClearLine(False, Row);
+end;
+
+procedure TExcelSheet.ClearLine(const AIsColumn: Boolean; const AIndex: Integer);
+begin
+  // Cells are stored sparse and keyed by address, so clearing a line is simply
+  // dropping the matching keys. Column widths, row heights, merges and freeze
+  // panes are left intact -- this clears contents, not structure.
+  var KeysToRemove := TList<string>.Create;
+  try
+    for var Pair in FCells do
+    begin
+      var Col, Row: Integer;
+      ParseCellAddress(Pair.Key, Col, Row);
+      if (AIsColumn and (Col = AIndex)) or ((not AIsColumn) and (Row = AIndex)) then
+        KeysToRemove.Add(Pair.Key);
+    end;
+    for var Key in KeysToRemove do
+      FCells.Remove(Key);
+  finally
+    KeysToRemove.Free;
+  end;
+end;
+
+procedure TExcelSheet.DeleteColumn(const Column: string);
+begin
+  DeleteLine(True, ColumnLetterToNumber(Column));
+end;
+
+procedure TExcelSheet.DeleteRow(const Row: Integer);
+begin
+  DeleteLine(False, Row);
+end;
+
+procedure TExcelSheet.DeleteLine(const AIsColumn: Boolean; const AIndex: Integer);
+begin
+  // 1. Cells: rebuild the address-keyed dictionary, dropping the deleted line and
+  //    shifting everything past it back by one. The cell (and its styling) moves as one.
+  var NewCells := TDictionary<string, IExcelCell>.Create;
+  for var Pair in FCells do
+  begin
+    var Col, Row: Integer;
+    ParseCellAddress(Pair.Key, Col, Row);
+    var Axis := Col;
+    if not AIsColumn then
+      Axis := Row;
+    if Axis = AIndex then
+      Continue;
+    if Axis > AIndex then
+      Dec(Axis);
+    if AIsColumn then
+      NewCells.Add(ColumnNumberToLetters(Axis) + IntToStr(Row), Pair.Value)
+    else
+      NewCells.Add(ColumnNumberToLetters(Col) + IntToStr(Axis), Pair.Value);
+  end;
+  FCells.Free;
+  FCells := NewCells;
+
+  // 2. Column widths (column delete) or row heights (row delete) shift the same way.
+  if AIsColumn then
+  begin
+    var NewWidths := TDictionary<string, Double>.Create;
+    for var Pair in FColumnWidths do
+    begin
+      var ColIdx := ColumnLetterToNumber(Pair.Key);
+      if ColIdx = AIndex then
+        Continue;
+      if ColIdx > AIndex then
+        Dec(ColIdx);
+      NewWidths.Add(ColumnNumberToLetters(ColIdx), Pair.Value);
+    end;
+    FColumnWidths.Free;
+    FColumnWidths := NewWidths;
+  end
+  else
+  begin
+    var NewHeights := TDictionary<Integer, Double>.Create;
+    for var Pair in FRowHeights do
+    begin
+      var RowIdx := Pair.Key;
+      if RowIdx = AIndex then
+        Continue;
+      if RowIdx > AIndex then
+        Dec(RowIdx);
+      NewHeights.Add(RowIdx, Pair.Value);
+    end;
+    FRowHeights.Free;
+    FRowHeights := NewHeights;
+  end;
+
+  // 3. Merged ranges: shrink, shift or drop each range on the deleted axis.
+  var NewMerges := TList<string>.Create;
+  for var Range in FMergedRanges do
+  begin
+    const ColonPos = Pos(':', Range);
+    if ColonPos = 0 then
+      Continue;
+    var C1, R1, C2, R2: Integer;
+    ParseCellAddress(Copy(Range, 1, ColonPos - 1), C1, R1);
+    ParseCellAddress(Copy(Range, ColonPos + 1, Length(Range)), C2, R2);
+
+    if AIsColumn then
+    begin
+      const Lo = Min(C1, C2);
+      const Hi = Max(C1, C2);
+      if (Lo = AIndex) and (Hi = AIndex) then
+        Continue;
+      C1 := ClampLo(Lo, AIndex);
+      C2 := ClampHi(Hi, AIndex);
+    end
+    else
+    begin
+      const Lo = Min(R1, R2);
+      const Hi = Max(R1, R2);
+      if (Lo = AIndex) and (Hi = AIndex) then
+        Continue;
+      R1 := ClampLo(Lo, AIndex);
+      R2 := ClampHi(Hi, AIndex);
+    end;
+
+    // A range that has collapsed to a single cell is no longer a merge.
+    if (C1 = C2) and (R1 = R2) then
+      Continue;
+    NewMerges.Add(ColumnNumberToLetters(C1) + IntToStr(R1) + ':' + ColumnNumberToLetters(C2) + IntToStr(R2));
+  end;
+  FMergedRanges.Free;
+  FMergedRanges := NewMerges;
+
+  // 4. Frozen pane counts: a deleted line at or before the frozen boundary shrinks it.
+  if AIsColumn then
+  begin
+    if AIndex <= FFrozenColumns then
+      Dec(FFrozenColumns);
+  end
+  else if AIndex <= FFrozenRows then
+    Dec(FFrozenRows);
+
+  // 5. Formulas: rewrite references across the whole workbook so cross-sheet refs to
+  //    this sheet are adjusted too. Falls back to self-scope if there is no owner.
+  if FOwner <> nil then
+    FOwner.ApplyFormulaDelete(Self, AIsColumn, AIndex)
+  else
+    RewriteOwnFormulas(AIsColumn, AIndex);
+end;
+
+procedure TExcelSheet.RewriteOwnFormulas(const AIsColumn: Boolean; const AIndex: Integer);
+begin
+  for var Pair in FCells do
+  begin
+    var Cell := Pair.Value as TExcelCell;
+    if Cell.GetHasFormula then
+    begin
+      const NewFormula = TransformFormulaForLineDelete(Cell.GetFormula, FName, FName, AIsColumn, AIndex);
+      if NewFormula <> Cell.GetFormula then
+        Cell.FFormula := NewFormula;
+    end;
+  end;
 end;
 
 { TExcelWorkbook }
@@ -1632,6 +2056,7 @@ begin
     if Match.Groups.Count > 1 then
     begin
       const Sheet = TExcelSheet.Create(Match.Groups[1].Value);
+      Sheet.FOwner := Self;
       const StateMatch = TRegEx.Match(Match.Groups[2].Value, 'state="([^"]+)"', [roIgnoreCase]);
       if StateMatch.Success then
       begin
@@ -2405,7 +2830,9 @@ end;
 
 function TExcelWorkbook.AddSheet(const Name: string): IExcelSheet;
 begin
-  Result := TExcelSheet.Create(Name);
+  var Sheet := TExcelSheet.Create(Name);
+  Sheet.FOwner := Self;
+  Result := Sheet;
   FSheets.Add(Result);
 end;
 
@@ -2415,6 +2842,47 @@ begin
     if SameText(Sheet.Name, Name) then
       Exit(Sheet);
   Result := nil;
+end;
+
+procedure TExcelWorkbook.RemoveSheet(Index: Integer);
+begin
+  if (Index < 0) or (Index >= FSheets.Count) then
+    raise EExcelWorkbookException.CreateFmt('Sheet index out of range: %d', [Index]);
+  // Excel refuses to open a workbook with no sheets, so keep at least one.
+  if FSheets.Count <= 1 then
+    raise EExcelWorkbookException.Create('A workbook must retain at least one sheet');
+  // sheetId/r:id and the sheetN.xml part names are derived positionally from the
+  // sheet order on save, so removing an entry is all that is needed.
+  FSheets.Delete(Index);
+end;
+
+procedure TExcelWorkbook.RemoveSheetByName(const Name: string);
+begin
+  for var I := 0 to FSheets.Count - 1 do
+    if SameText(FSheets[I].Name, Name) then
+    begin
+      RemoveSheet(I);
+      Exit;
+    end;
+  raise EExcelWorkbookException.CreateFmt('Sheet not found: "%s"', [Name]);
+end;
+
+procedure TExcelWorkbook.ApplyFormulaDelete(const ATargetSheet: TExcelSheet; const AIsColumn: Boolean; const ALineIndex: Integer);
+begin
+  for var SheetIntf in FSheets do
+  begin
+    var Sheet := SheetIntf as TExcelSheet;
+    for var Pair in Sheet.Cells do
+    begin
+      var Cell := Pair.Value as TExcelCell;
+      if Cell.GetHasFormula then
+      begin
+        const NewFormula = TransformFormulaForLineDelete(Cell.GetFormula, ATargetSheet.GetName, Sheet.GetName, AIsColumn, ALineIndex);
+        if NewFormula <> Cell.GetFormula then
+          Cell.FFormula := NewFormula;
+      end;
+    end;
+  end;
 end;
 
 end.

--- a/Source/Excel/Office4D.Excel.pas
+++ b/Source/Excel/Office4D.Excel.pas
@@ -115,6 +115,11 @@ type
     function GetFrozenRows: Integer;
     function GetFrozenColumns: Integer;
 
+    procedure ClearColumn(const Column: string);
+    procedure ClearRow(const Row: Integer);
+    procedure DeleteColumn(const Column: string);
+    procedure DeleteRow(const Row: Integer);
+
     function GetCells: TDictionary<string, IExcelCell>;
 
     property Name: string read GetName;
@@ -138,6 +143,8 @@ type
     function GetMetadata: TDocumentMetadata;
 
     function AddSheet(const Name: string): IExcelSheet;
+    procedure RemoveSheet(Index: Integer);
+    procedure RemoveSheetByName(const Name: string);
 
     property SheetCount: Integer read GetSheetCount;
     property Sheets[Index: Integer]: IExcelSheet read GetSheet;

--- a/Tests/Source/Office4D.Tests.Excel.ClearColumnRow.pas
+++ b/Tests/Source/Office4D.Tests.Excel.ClearColumnRow.pas
@@ -1,0 +1,123 @@
+unit Office4D.Tests.Excel.ClearColumnRow;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelClearColumnRowTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FSheet: IExcelSheet;
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure ClearColumn_RemovesColumnCells_KeepsNeighbours;
+
+    [Test]
+    procedure ClearRow_RemovesRowCells_KeepsNeighbours;
+
+    [Test]
+    procedure ClearColumn_KeepsColumnWidthAndMerges;
+
+    [Test]
+    procedure ClearColumn_NonExisting_IsNoOp;
+
+    [Test]
+    procedure ClearRow_NonExisting_IsNoOp;
+  end;
+
+implementation
+
+{ TExcelClearColumnRowTests }
+
+procedure TExcelClearColumnRowTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FSheet := FWorkbook.AddSheet('Sheet1');
+end;
+
+procedure TExcelClearColumnRowTests.TearDown;
+begin
+  FSheet := nil;
+  FWorkbook := nil;
+end;
+
+procedure TExcelClearColumnRowTests.ClearColumn_RemovesColumnCells_KeepsNeighbours;
+begin
+  FSheet.Cell['A1'].AsString := 'a1';
+  FSheet.Cell['B1'].AsString := 'b1';
+  FSheet.Cell['B2'].AsString := 'b2';
+  FSheet.Cell['C1'].AsString := 'c1';
+
+  FSheet.ClearColumn('B');
+
+  Assert.IsFalse(FSheet.Cells.ContainsKey('B1'), 'B1 must be cleared');
+  Assert.IsFalse(FSheet.Cells.ContainsKey('B2'), 'B2 must be cleared');
+  Assert.IsTrue(FSheet.Cells.ContainsKey('A1'), 'The neighbouring column A must be untouched');
+  Assert.IsTrue(FSheet.Cells.ContainsKey('C1'), 'The neighbouring column C must be untouched');
+end;
+
+procedure TExcelClearColumnRowTests.ClearRow_RemovesRowCells_KeepsNeighbours;
+begin
+  FSheet.Cell['A1'].AsString := 'a1';
+  FSheet.Cell['B1'].AsString := 'b1';
+  FSheet.Cell['A2'].AsString := 'a2';
+  FSheet.Cell['A3'].AsString := 'a3';
+
+  FSheet.ClearRow(2);
+
+  Assert.IsFalse(FSheet.Cells.ContainsKey('A2'), 'A2 must be cleared');
+  Assert.IsTrue(FSheet.Cells.ContainsKey('A1'), 'Row 1 must be untouched');
+  Assert.IsTrue(FSheet.Cells.ContainsKey('B1'), 'Row 1 must be untouched');
+  Assert.IsTrue(FSheet.Cells.ContainsKey('A3'), 'Row 3 must be untouched');
+end;
+
+procedure TExcelClearColumnRowTests.ClearColumn_KeepsColumnWidthAndMerges;
+begin
+  FSheet.Cell['B1'].AsString := 'b1';
+  FSheet.SetColumnWidth('B', 25);
+  FSheet.MergeCells('B1:B3');
+
+  FSheet.ClearColumn('B');
+
+  // Clear removes contents, not structure: width and merges survive.
+  Assert.AreEqual(Double(25), FSheet.GetColumnWidth('B'), 0.001, 'Clearing contents must keep the column width');
+  Assert.AreEqual(1, Integer(Length(FSheet.GetMergedRanges)), 'Clearing contents must keep merged ranges');
+end;
+
+procedure TExcelClearColumnRowTests.ClearColumn_NonExisting_IsNoOp;
+begin
+  FSheet.Cell['A1'].AsString := 'a1';
+
+  // Clearing an empty column must be a no-op; a raised exception would fail the test.
+  FSheet.ClearColumn('Z');
+
+  Assert.IsTrue(FSheet.Cells.ContainsKey('A1'));
+end;
+
+procedure TExcelClearColumnRowTests.ClearRow_NonExisting_IsNoOp;
+begin
+  FSheet.Cell['A1'].AsString := 'a1';
+
+  // Clearing an empty row must be a no-op; a raised exception would fail the test.
+  FSheet.ClearRow(99);
+
+  Assert.IsTrue(FSheet.Cells.ContainsKey('A1'));
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelClearColumnRowTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.Excel.DeleteColumnRow.pas
+++ b/Tests/Source/Office4D.Tests.Excel.DeleteColumnRow.pas
@@ -1,0 +1,326 @@
+unit Office4D.Tests.Excel.DeleteColumnRow;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelDeleteColumnRowTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FSheet: IExcelSheet;
+    FTempFile: string;
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    // --- Reflow of cells and structure ---
+    [Test]
+    procedure DeleteColumn_ShiftsCellsLeftAndDropsDeleted;
+
+    [Test]
+    procedure DeleteColumn_MovesCellStyleWithTheCell;
+
+    [Test]
+    procedure DeleteColumn_ShiftsColumnWidths;
+
+    [Test]
+    procedure DeleteRow_ShiftsCellsUpAndDropsDeleted;
+
+    [Test]
+    procedure DeleteRow_ShiftsRowHeights;
+
+    [Test]
+    procedure DeleteColumn_ShrinksFrozenColumns_LeavesRows;
+
+    [Test]
+    procedure DeleteColumn_MergedRangeShrinks;
+
+    [Test]
+    procedure DeleteColumn_MergedRangeFullyOnColumn_IsDropped;
+
+    [Test]
+    procedure RoundTrip_DeleteColumn_Persists;
+
+    // --- Formula reference rewriting ---
+    [Test]
+    procedure DeleteColumn_Formula_RefAfterDeleted_ShiftsLeft;
+
+    [Test]
+    procedure DeleteColumn_Formula_RefBeforeDeleted_Unchanged;
+
+    [Test]
+    procedure DeleteColumn_Formula_RefOnDeleted_BecomesRefError;
+
+    [Test]
+    procedure DeleteColumn_Formula_AbsoluteRef_IsAlsoShifted;
+
+    [Test]
+    procedure DeleteColumn_Formula_RangeShrinks;
+
+    [Test]
+    procedure DeleteColumn_Formula_RangeEndOnDeleted_ClampsNotRefError;
+
+    [Test]
+    procedure DeleteColumn_Formula_RangeFullyOnColumn_BecomesRefError;
+
+    [Test]
+    procedure DeleteColumn_Formula_CrossSheetRef_IsShifted;
+
+    [Test]
+    procedure DeleteColumn_Formula_RefToOtherSheet_Untouched;
+
+    [Test]
+    procedure DeleteColumn_Formula_StringLiteral_Untouched;
+
+    [Test]
+    procedure DeleteRow_Formula_RefBelowDeleted_ShiftsUp;
+  end;
+
+implementation
+
+{ TExcelDeleteColumnRowTests }
+
+procedure TExcelDeleteColumnRowTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FSheet := FWorkbook.AddSheet('Sheet1');
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'deletecolrow_test_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelDeleteColumnRowTests.TearDown;
+begin
+  FSheet := nil;
+  FWorkbook := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_ShiftsCellsLeftAndDropsDeleted;
+begin
+  FSheet.Cell['A1'].AsString := 'a';
+  FSheet.Cell['B1'].AsString := 'b';
+  FSheet.Cell['C1'].AsString := 'c';
+  FSheet.Cell['D1'].AsString := 'd';
+
+  FSheet.DeleteColumn('B');
+
+  Assert.AreEqual('a', FSheet.Cell['A1'].AsString, 'Column before the deleted one stays put');
+  Assert.AreEqual('c', FSheet.Cell['B1'].AsString, 'Column C shifts into B');
+  Assert.AreEqual('d', FSheet.Cell['C1'].AsString, 'Column D shifts into C');
+  Assert.IsFalse(FSheet.Cells.ContainsKey('D1'), 'The trailing column must be empty after the shift');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_MovesCellStyleWithTheCell;
+begin
+  FSheet.Cell['C1'].AsString := 'x';
+  FSheet.Cell['C1'].Bold := True;
+
+  FSheet.DeleteColumn('B');
+
+  Assert.AreEqual('x', FSheet.Cell['B1'].AsString, 'C1 moves to B1');
+  Assert.IsTrue(FSheet.Cell['B1'].Bold, 'Styling travels with the cell');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_ShiftsColumnWidths;
+begin
+  FSheet.SetColumnWidth('B', 10);
+  FSheet.SetColumnWidth('C', 20);
+  FSheet.SetColumnWidth('D', 30);
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual(Double(10), FSheet.GetColumnWidth('B'), 0.001, 'Width before the deleted column is unchanged');
+  Assert.AreEqual(Double(30), FSheet.GetColumnWidth('C'), 0.001, 'Width of column D shifts into C');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteRow_ShiftsCellsUpAndDropsDeleted;
+begin
+  FSheet.Cell['A1'].AsString := 'r1';
+  FSheet.Cell['A2'].AsString := 'r2';
+  FSheet.Cell['A3'].AsString := 'r3';
+
+  FSheet.DeleteRow(2);
+
+  Assert.AreEqual('r1', FSheet.Cell['A1'].AsString);
+  Assert.AreEqual('r3', FSheet.Cell['A2'].AsString, 'Row 3 shifts up into row 2');
+  Assert.IsFalse(FSheet.Cells.ContainsKey('A3'), 'The trailing row must be empty after the shift');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteRow_ShiftsRowHeights;
+begin
+  FSheet.SetRowHeight(1, 10);
+  FSheet.SetRowHeight(2, 20);
+  FSheet.SetRowHeight(3, 30);
+
+  FSheet.DeleteRow(2);
+
+  Assert.AreEqual(Double(10), FSheet.GetRowHeight(1), 0.001);
+  Assert.AreEqual(Double(30), FSheet.GetRowHeight(2), 0.001, 'Height of row 3 shifts up into row 2');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_ShrinksFrozenColumns_LeavesRows;
+begin
+  FSheet.FreezePanes('C2'); // 2 frozen columns, 1 frozen row
+
+  FSheet.DeleteColumn('A'); // inside the frozen region
+
+  Assert.AreEqual(1, FSheet.FrozenColumns, 'Deleting a frozen column shrinks the frozen column count');
+  Assert.AreEqual(1, FSheet.FrozenRows, 'The frozen row count is unaffected by a column delete');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_MergedRangeShrinks;
+begin
+  FSheet.MergeCells('B1:D1');
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual(1, Integer(Length(FSheet.GetMergedRanges)));
+  Assert.AreEqual('B1:C1', FSheet.GetMergedRanges[0], 'The merged range shrinks by one column');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_MergedRangeFullyOnColumn_IsDropped;
+begin
+  FSheet.MergeCells('C1:C3');
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual(0, Integer(Length(FSheet.GetMergedRanges)), 'A merge entirely on the deleted column disappears');
+end;
+
+procedure TExcelDeleteColumnRowTests.RoundTrip_DeleteColumn_Persists;
+begin
+  FSheet.Cell['A1'].AsString := 'a';
+  FSheet.Cell['B1'].AsString := 'b';
+  FSheet.Cell['C1'].AsString := 'c';
+
+  FSheet.DeleteColumn('B');
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Reloaded = TExcelWorkbookFactory.Create;
+  Reloaded.LoadFromFile(FTempFile);
+  const Sheet = Reloaded.Sheets[0];
+
+  Assert.AreEqual('a', Sheet.Cell['A1'].AsString);
+  Assert.AreEqual('c', Sheet.Cell['B1'].AsString, 'The shifted layout must survive a save/load round-trip');
+  Assert.IsFalse(Sheet.Cells.ContainsKey('C1'));
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RefAfterDeleted_ShiftsLeft;
+begin
+  FSheet.Cell['A1'].SetFormula('D1', 0);
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual('C1', FSheet.Cell['A1'].Formula, 'A reference past the deleted column shifts left');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RefBeforeDeleted_Unchanged;
+begin
+  FSheet.Cell['A1'].SetFormula('B1', 0);
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual('B1', FSheet.Cell['A1'].Formula, 'A reference before the deleted column is untouched');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RefOnDeleted_BecomesRefError;
+begin
+  FSheet.Cell['A1'].SetFormula('C1', 0);
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual('#REF!', FSheet.Cell['A1'].Formula, 'A reference to the deleted column becomes #REF!');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_AbsoluteRef_IsAlsoShifted;
+begin
+  FSheet.Cell['A1'].SetFormula('$D$1', 0);
+
+  FSheet.DeleteColumn('C');
+
+  // Unlike a copy, a delete shifts absolute references too.
+  Assert.AreEqual('$C$1', FSheet.Cell['A1'].Formula, 'An absolute reference is shifted on delete');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RangeShrinks;
+begin
+  FSheet.Cell['A1'].SetFormula('SUM(B1:D1)', 0);
+
+  FSheet.DeleteColumn('C');
+
+  Assert.AreEqual('SUM(B1:C1)', FSheet.Cell['A1'].Formula, 'A range spanning the deleted column shrinks');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RangeEndOnDeleted_ClampsNotRefError;
+begin
+  FSheet.Cell['A1'].SetFormula('SUM(A2:C2)', 0);
+
+  FSheet.DeleteColumn('C');
+
+  // The far edge sat on the deleted column, so the range clamps to the column before it.
+  Assert.AreEqual('SUM(A2:B2)', FSheet.Cell['A1'].Formula);
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RangeFullyOnColumn_BecomesRefError;
+begin
+  FSheet.Cell['A1'].SetFormula('SUM(C1:C5)', 0);
+
+  FSheet.DeleteColumn('C');
+
+  // Excel collapses the range itself to #REF! but keeps the surrounding function.
+  Assert.AreEqual('SUM(#REF!)', FSheet.Cell['A1'].Formula, 'A range entirely on the deleted column becomes #REF!');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_CrossSheetRef_IsShifted;
+begin
+  const Sheet2 = FWorkbook.AddSheet('Sheet2');
+  FSheet.Cell['A1'].SetFormula('Sheet2!D1', 0);
+
+  Sheet2.DeleteColumn('C');
+
+  Assert.AreEqual('Sheet2!C1', FSheet.Cell['A1'].Formula, 'A cross-sheet reference to the edited sheet shifts too');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_RefToOtherSheet_Untouched;
+begin
+  FWorkbook.AddSheet('Sheet2');
+  FSheet.Cell['A1'].SetFormula('Sheet2!D1', 0);
+
+  FSheet.DeleteColumn('C'); // delete on Sheet1, not Sheet2
+
+  Assert.AreEqual('Sheet2!D1', FSheet.Cell['A1'].Formula, 'A reference to a different sheet is left alone');
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteColumn_Formula_StringLiteral_Untouched;
+begin
+  FSheet.Cell['A1'].SetFormula('CONCATENATE("see C3",D1)', 0);
+
+  FSheet.DeleteColumn('C');
+
+  // The literal text "see C3" must not be treated as a reference; D1 still shifts to C1.
+  Assert.AreEqual('CONCATENATE("see C3",C1)', FSheet.Cell['A1'].Formula);
+end;
+
+procedure TExcelDeleteColumnRowTests.DeleteRow_Formula_RefBelowDeleted_ShiftsUp;
+begin
+  FSheet.Cell['A1'].SetFormula('A5', 0);
+
+  FSheet.DeleteRow(3);
+
+  Assert.AreEqual('A4', FSheet.Cell['A1'].Formula, 'A reference below the deleted row shifts up');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelDeleteColumnRowTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.Excel.RemoveSheet.pas
+++ b/Tests/Source/Office4D.Tests.Excel.RemoveSheet.pas
@@ -1,0 +1,155 @@
+unit Office4D.Tests.Excel.RemoveSheet;
+
+interface
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  DUnitX.TestFramework,
+  Office4D.Tests.Samples,
+  Office4D.Excel;
+
+type
+  [TestFixture]
+  TExcelRemoveSheetTests = class(TOffice4DTests)
+  private
+    FWorkbook: IExcelWorkbook;
+    FTempFile: string;
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure RemoveSheet_ByIndex_DecrementsCountAndKeepsOthers;
+
+    [Test]
+    procedure RemoveSheetByName_RemovesTheNamedSheet;
+
+    [Test]
+    procedure RemoveSheet_IndexOutOfRange_Raises;
+
+    [Test]
+    procedure RemoveSheetByName_UnknownName_Raises;
+
+    [Test]
+    procedure RemoveSheet_LastRemainingSheet_Raises;
+
+    [Test]
+    procedure RoundTrip_AfterRemove_SheetsRenumberedSequentially;
+  end;
+
+implementation
+
+uses
+  Office4D.Errors;
+
+{ TExcelRemoveSheetTests }
+
+procedure TExcelRemoveSheetTests.Setup;
+begin
+  FWorkbook := TExcelWorkbookFactory.Create;
+  FTempFile := TPath.Combine(TPath.GetTempPath, 'removesheet_test_' + TGUID.NewGuid.ToString + '.xlsx');
+end;
+
+procedure TExcelRemoveSheetTests.TearDown;
+begin
+  FWorkbook := nil;
+  if TFile.Exists(FTempFile) then
+    TFile.Delete(FTempFile);
+end;
+
+procedure TExcelRemoveSheetTests.RemoveSheet_ByIndex_DecrementsCountAndKeepsOthers;
+begin
+  FWorkbook.AddSheet('Alpha');
+  FWorkbook.AddSheet('Beta');
+  FWorkbook.AddSheet('Gamma');
+
+  FWorkbook.RemoveSheet(1); // Beta
+
+  Assert.AreEqual(2, FWorkbook.SheetCount, 'Removing a sheet must decrement the count');
+  Assert.AreEqual('Alpha', FWorkbook.Sheets[0].Name);
+  Assert.AreEqual('Gamma', FWorkbook.Sheets[1].Name, 'The sheet after the removed one must slide into its place');
+end;
+
+procedure TExcelRemoveSheetTests.RemoveSheetByName_RemovesTheNamedSheet;
+begin
+  FWorkbook.AddSheet('Alpha');
+  FWorkbook.AddSheet('Beta');
+  FWorkbook.AddSheet('Gamma');
+
+  FWorkbook.RemoveSheetByName('Beta');
+
+  Assert.AreEqual(2, FWorkbook.SheetCount);
+  Assert.IsNull(FWorkbook.SheetByName('Beta'), 'The named sheet must be gone');
+  Assert.IsNotNull(FWorkbook.SheetByName('Alpha'));
+  Assert.IsNotNull(FWorkbook.SheetByName('Gamma'));
+end;
+
+procedure TExcelRemoveSheetTests.RemoveSheet_IndexOutOfRange_Raises;
+begin
+  FWorkbook.AddSheet('Alpha');
+  FWorkbook.AddSheet('Beta');
+
+  Assert.WillRaise(
+    procedure
+    begin
+      FWorkbook.RemoveSheet(5);
+    end,
+    EExcelWorkbookException,
+    'An out-of-range index must raise rather than silently doing nothing');
+end;
+
+procedure TExcelRemoveSheetTests.RemoveSheetByName_UnknownName_Raises;
+begin
+  FWorkbook.AddSheet('Alpha');
+  FWorkbook.AddSheet('Beta');
+
+  Assert.WillRaise(
+    procedure
+    begin
+      FWorkbook.RemoveSheetByName('DoesNotExist');
+    end,
+    EExcelWorkbookException,
+    'Removing an unknown sheet name must raise');
+end;
+
+procedure TExcelRemoveSheetTests.RemoveSheet_LastRemainingSheet_Raises;
+begin
+  FWorkbook.AddSheet('Only');
+
+  // Excel refuses to open a workbook with no sheets, so the last one cannot be removed.
+  Assert.WillRaise(
+    procedure
+    begin
+      FWorkbook.RemoveSheet(0);
+    end,
+    EExcelWorkbookException,
+    'Removing the last remaining sheet must raise');
+end;
+
+procedure TExcelRemoveSheetTests.RoundTrip_AfterRemove_SheetsRenumberedSequentially;
+begin
+  FWorkbook.AddSheet('Alpha').Cell['A1'].AsString := 'a';
+  FWorkbook.AddSheet('Beta').Cell['A1'].AsString := 'b';
+  FWorkbook.AddSheet('Gamma').Cell['A1'].AsString := 'g';
+
+  FWorkbook.RemoveSheet(1); // Beta
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Reloaded = TExcelWorkbookFactory.Create;
+  Reloaded.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(2, Reloaded.SheetCount, 'The saved workbook must contain only the surviving sheets');
+  Assert.AreEqual('Alpha', Reloaded.Sheets[0].Name);
+  Assert.AreEqual('Gamma', Reloaded.Sheets[1].Name);
+  Assert.AreEqual('a', Reloaded.Sheets[0].Cell['A1'].AsString, 'Surviving sheet content must be intact');
+  Assert.AreEqual('g', Reloaded.Sheets[1].Cell['A1'].AsString);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TExcelRemoveSheetTests);
+
+end.

--- a/Tests/Source/Office4D.Tests.dpr
+++ b/Tests/Source/Office4D.Tests.dpr
@@ -34,7 +34,10 @@ uses
   Office4D.Tests.PowerPoint in 'Office4D.Tests.PowerPoint.pas',
   Office4D.Tests.Excel.BorderSides in 'Office4D.Tests.Excel.BorderSides.pas',
   Office4D.Tests.Excel.FontStyle in 'Office4D.Tests.Excel.FontStyle.pas',
-  Office4D.Tests.Excel.FreezePanes in 'Office4D.Tests.Excel.FreezePanes.pas';
+  Office4D.Tests.Excel.FreezePanes in 'Office4D.Tests.Excel.FreezePanes.pas',
+  Office4D.Tests.Excel.RemoveSheet in 'Office4D.Tests.Excel.RemoveSheet.pas',
+  Office4D.Tests.Excel.ClearColumnRow in 'Office4D.Tests.Excel.ClearColumnRow.pas',
+  Office4D.Tests.Excel.DeleteColumnRow in 'Office4D.Tests.Excel.DeleteColumnRow.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Source/Office4D.Tests.dproj
+++ b/Tests/Source/Office4D.Tests.dproj
@@ -167,6 +167,9 @@
         <DCCReference Include="Office4D.Tests.Excel.BorderSides.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.FontStyle.pas"/>
         <DCCReference Include="Office4D.Tests.Excel.FreezePanes.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.RemoveSheet.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.ClearColumnRow.pas"/>
+        <DCCReference Include="Office4D.Tests.Excel.DeleteColumnRow.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
Adds three editing operations to the Excel API:

- `RemoveSheet` / `RemoveSheetByName` on the workbook (keeps at least one sheet)
- `ClearColumn` / `ClearRow` on a sheet (clears contents, keeps column widths, row heights, merges and freeze panes)
- `DeleteColumn` / `DeleteRow` with full reflow of cells, column widths, row heights, merged ranges and freeze panes, plus workbook-wide formula-reference rewriting (absolute refs and ranges included, cross-sheet refs adjusted, and a deleted line becomes `#REF!` like Excel)

Covered by 31 new DUnitX tests; full suite (287) passes.
