### PR TITLE
Preserve built-in currency and accounting number formats

### DIFF
--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -2427,6 +2427,9 @@ procedure TExcelWorkbook.ParseStyles(const Xml: string);
   // section 18.8.30). Files authored by Excel reference these by id only,
   // without a <numFmt> element, so the codes have to be supplied here to
   // survive a round-trip (they are re-emitted as custom formats on save).
+  // The codes use Excel's own literal forms (the "_)" width-padding token
+  // and the quoted "$" currency literal); Excel substitutes the locale
+  // currency symbol for "$" on display, which is a rendering concern only.
   function BuiltInFormatCode(const NumFmtId: Integer): string;
   begin
     case NumFmtId of
@@ -2434,15 +2437,23 @@ procedure TExcelWorkbook.ParseStyles(const Xml: string);
       2: Result := '0.00';
       3: Result := '#,##0';
       4: Result := '#,##0.00';
+      5: Result := '"$"#,##0_);("$"#,##0)';
+      6: Result := '"$"#,##0_);[Red]("$"#,##0)';
+      7: Result := '"$"#,##0.00_);("$"#,##0.00)';
+      8: Result := '"$"#,##0.00_);[Red]("$"#,##0.00)';
       9: Result := '0%';
       10: Result := '0.00%';
       11: Result := '0.00E+00';
       12: Result := '# ?/?';
       13: Result := '# ??/??';
-      37: Result := '#,##0 ;(#,##0)';
-      38: Result := '#,##0 ;[Red](#,##0)';
-      39: Result := '#,##0.00;(#,##0.00)';
-      40: Result := '#,##0.00;[Red](#,##0.00)';
+      37: Result := '#,##0_);(#,##0)';
+      38: Result := '#,##0_);[Red](#,##0)';
+      39: Result := '#,##0.00_);(#,##0.00)';
+      40: Result := '#,##0.00_);[Red](#,##0.00)';
+      41: Result := '_(* #,##0_);_(* (#,##0);_(* "-"_);_(@_)';
+      42: Result := '_("$"* #,##0_);_("$"* (#,##0);_("$"* "-"_);_(@_)';
+      43: Result := '_(* #,##0.00_);_(* (#,##0.00);_(* "-"??_);_(@_)';
+      44: Result := '_("$"* #,##0.00_);_("$"* (#,##0.00);_("$"* "-"??_);_(@_)';
       48: Result := '##0.0E+0';
       49: Result := '@';
     else

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -218,6 +218,9 @@ type
 
     [Test]
     procedure LoadFromFile_ExcelAuthoredNumberFormats_ArePreserved;
+
+    [Test]
+    procedure LoadFromFile_ExcelAuthoredCurrencyAndAccountingFormats_ArePreserved;
   end;
 
 implementation
@@ -1388,6 +1391,80 @@ begin
     Workbook2.LoadFromFile(FTempFile);
     Assert.AreEqual('0.000', Workbook2.Sheets[0].Cell['A1'].NumberFormat, 'Custom format should survive a resave');
     Assert.AreEqual('0%', Workbook2.Sheets[0].Cell['B1'].NumberFormat, 'Built-in format should survive a resave');
+  finally
+    Zip.Free;
+    if TFile.Exists(SourceFile) then
+      TFile.Delete(SourceFile);
+  end;
+end;
+
+procedure TExcelWriteTests.LoadFromFile_ExcelAuthoredCurrencyAndAccountingFormats_ArePreserved;
+
+  procedure AddPart(const Zip: TZipFile; const PartName, Content: string);
+  begin
+    Zip.Add(TEncoding.UTF8.GetBytes(Content), PartName);
+  end;
+
+const
+  SpreadsheetNs = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+  OfficeDocRelsNs = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  CurrencyCode = '"$"#,##0.00_);("$"#,##0.00)';
+  AccountingCode = '_("$"* #,##0.00_);_("$"* (#,##0.00);_("$"* "-"??_);_(@_)';
+  NumberCode = '#,##0_);(#,##0)';
+begin
+  // Excel references the built-in currency (7), accounting (44) and number (37)
+  // formats by id only, with no <numFmt> element, so the library must supply the
+  // codes. The currency and accounting codes carry quoted "$"/"-" literals, which
+  // exercise the XML quote-escaping on the re-save path.
+  const SourceFile = TPath.Combine(TPath.GetTempPath, 'excel_builtin_' + TGUID.NewGuid.ToString + '.xlsx');
+  var Zip := TZipFile.Create;
+  try
+    Zip.Open(SourceFile, zmWrite);
+    AddPart(Zip, 'xl/workbook.xml',
+      '<workbook xmlns="' + SpreadsheetNs + '" xmlns:r="' + OfficeDocRelsNs + '">' +
+      '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>');
+    AddPart(Zip, 'xl/styles.xml',
+      '<styleSheet xmlns="' + SpreadsheetNs + '">' +
+      '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+      '<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>' +
+      '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+      '<cellXfs count="4">' +
+      '<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>' +
+      '<xf numFmtId="7" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>' +
+      '<xf numFmtId="44" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>' +
+      '<xf numFmtId="37" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>' +
+      '</cellXfs></styleSheet>');
+    AddPart(Zip, 'xl/worksheets/sheet1.xml',
+      '<worksheet xmlns="' + SpreadsheetNs + '"><sheetData>' +
+      '<row r="1">' +
+      '<c r="A1" s="1"><v>1234.5</v></c>' +
+      '<c r="B1" s="2"><v>1234.5</v></c>' +
+      '<c r="C1" s="3"><v>1234</v></c>' +
+      '</row></sheetData></worksheet>');
+    Zip.Close;
+
+    FWorkbook.LoadFromFile(SourceFile);
+    Assert.AreEqual(CurrencyCode, FWorkbook.Sheets[0].Cell['A1'].NumberFormat, 'Built-in numFmt 7 should map to the currency format code');
+    Assert.AreEqual(AccountingCode, FWorkbook.Sheets[0].Cell['B1'].NumberFormat, 'Built-in numFmt 44 should map to the accounting format code');
+    Assert.AreEqual(NumberCode, FWorkbook.Sheets[0].Cell['C1'].NumberFormat, 'Built-in numFmt 37 should map to the number format code');
+    Assert.AreEqual(Double(1234.5), FWorkbook.Sheets[0].Cell['A1'].AsFloat, 0.001, 'Currency-formatted cell should read as a plain number, not a date');
+
+    FWorkbook.SaveToFile(FTempFile);
+
+    var Package := TOXMLPackage.Create;
+    try
+      Package.Open(FTempFile);
+      const StylesXml = Package.GetPartContent('xl/styles.xml');
+      Assert.IsTrue(Pos('&quot;$&quot;', StylesXml) > 0, 'Resaved styles.xml should XML-escape the quoted currency literal');
+    finally
+      Package.Free;
+    end;
+
+    const Workbook2 = TExcelWorkbookFactory.Create;
+    Workbook2.LoadFromFile(FTempFile);
+    Assert.AreEqual(CurrencyCode, Workbook2.Sheets[0].Cell['A1'].NumberFormat, 'Currency format should survive a resave');
+    Assert.AreEqual(AccountingCode, Workbook2.Sheets[0].Cell['B1'].NumberFormat, 'Accounting format should survive a resave');
+    Assert.AreEqual(NumberCode, Workbook2.Sheets[0].Cell['C1'].NumberFormat, 'Number format should survive a resave');
   finally
     Zip.Free;
     if TFile.Exists(SourceFile) then


### PR DESCRIPTION
## Problem

PR #30 taught the loader to map the non-date built-in `numFmtId`s to their
format codes, but only covered a subset (1-4, 9-13, 37-40, 48, 49). Excel-authored
files that reference the built-in **currency** formats (ids 5-8) or **accounting**
formats (ids 41-44) by id, with no `<numFmt>` element, still lost their formatting
on a load/save round-trip and fell back to *General*.

## Fix

- Extend `BuiltInFormatCode` with the ECMA-376 §18.8.30 currency (5-8) and
  accounting (41-44) format codes. On save they are re-emitted as custom formats
  (id 165+), which renders identically, exactly like the ids added in #30.
- Normalise the existing 37-40 codes to Excel's own literal form (the `_)`
  width-padding token, e.g. `#,##0_);(#,##0)`) so the whole table uses one
  convention. The accounting codes are structurally built on that token
  regardless, so a single convention is the only way to keep the `case` uniform.
  No existing test asserts the old 37-40 strings, so this is a pure normalisation.

The currency and accounting codes carry quoted `"$"`/`"-"` literals. These
round-trip through the existing XML escaping (`TXml.Escape`/`Unescape` already
map `"` ↔ `&quot;`), so no change to the XML layer was needed.

## Out of scope

Built-in East-Asian locale date ids (27-36, 50-81) are still not recognised as
dates; that needs changes to `IsBuiltInDateNumFmtId` and the date parsing and is a
separate follow-up.

## Tests

- `LoadFromFile_ExcelAuthoredCurrencyAndAccountingFormats_ArePreserved` — loads a
  hand-built xlsx referencing `numFmtId` 7 (currency), 44 (accounting) and 37
  (number), asserts the mapped codes are applied, that the currency cell reads as a
  plain number (not a date), that all three survive a resave, and that the quoted
  currency literal is XML-escaped in the regenerated styles.xml.

All 307 tests pass; normalising 37-40 broke no existing test.