### PR TITLE
Excel sheet name missing escaping

### DIFF
--- a/Source/Excel/Office4D.Excel.Reader.pas
+++ b/Source/Excel/Office4D.Excel.Reader.pas
@@ -98,7 +98,7 @@ begin
   for var Match in Matches do
     if Match.Groups.Count > 1 then
     begin
-      const Sheet = FContent.CreateSheet(Match.Groups[1].Value);
+      const Sheet = FContent.CreateSheet(TXml.Unescape(Match.Groups[1].Value));
       const StateMatch = TRegEx.Match(Match.Groups[2].Value, 'state="([^"]+)"', [roIgnoreCase]);
       if StateMatch.Success then
       begin

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -1,4 +1,4 @@
-unit Office4D.Excel.Writer;
+﻿unit Office4D.Excel.Writer;
 
 interface
 
@@ -223,7 +223,7 @@ begin
         StateAttr := ' state="hidden"'
       else if FContent.Sheets[I].Visibility = TExcelSheetVisibility.VeryHidden then
         StateAttr := ' state="veryHidden"';
-      SB.Append('<sheet name="' + FContent.Sheets[I].Name + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>');
+      SB.Append('<sheet name="' + TXml.Escape(FContent.Sheets[I].Name) + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>')
     end;
     SB.Append('</sheets>');
     SB.Append('</workbook>');

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -37,6 +37,9 @@ type
     procedure RoundTrip_SpecialCharacters_ArePreserved;
 
     [Test]
+    procedure RoundTrip_SheetNameWithSpecialCharacters_ArePreserved;
+
+    [Test]
     procedure SaveToFile_ValidatesAsZip;
 
     [Test]
@@ -1228,6 +1231,22 @@ begin
   const Workbook2 = TExcelWorkbookFactory.Create;
   Workbook2.LoadFromFile(FTempFile);
   Assert.AreEqual(Special, Workbook2.Sheets[0].Cell['A1'].AsString, 'Cell special characters should round-trip');
+end;
+
+procedure TExcelWriteTests.RoundTrip_SheetNameWithSpecialCharacters_ArePreserved;
+begin
+  // None of these characters are in Excel's forbidden sheet-name set (\ / ? * [ ] :),
+  // so this is a legal sheet name -- the sheet name itself must still be XML-escaped
+  // when written into workbook.xml and unescaped when read back, same as any other
+  // user-supplied text in this library.
+  const SpecialName = 'R&D <tag> "q" ''a'' 5>3';
+  FWorkbook.AddSheet(SpecialName);
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual(SpecialName, Workbook2.Sheets[0].Name, 'Sheet name special characters should round-trip');
 end;
 
 procedure TExcelWriteTests.AddSheet_NewSheet_IsVisible;


### PR DESCRIPTION
The sheet name was missing escaping and unescaping - so "R & D" as name would corrupt the file.