### PR TITLE
Escape formula text in Excel cell XML

### DIFF
--- a/Source/Excel/Office4D.Excel.Reader.pas
+++ b/Source/Excel/Office4D.Excel.Reader.pas
@@ -730,7 +730,7 @@ begin
         const SiIdx = StrToIntDef(SfMatch.Groups[2].Value, -1);
         if SiIdx >= 0 then
           SharedFormulas.AddOrSetValue(SiIdx,
-            TPair<string, string>.Create(SfMatch.Groups[1].Value, SfMatch.Groups[3].Value));
+            TPair<string, string>.Create(SfMatch.Groups[1].Value, TXml.Unescape(SfMatch.Groups[3].Value)));
       end;
 
     // Match each cell element. Self-closing <c r=".."/> empty cells are excluded via
@@ -751,7 +751,7 @@ begin
         const Address = Match.Groups[1].Value;
         const StyleIdx = StrToIntDef(Match.Groups[2].Value, 0);
         const CellType = Match.Groups[3].Value;
-        var   Formula: string := Match.Groups[4].Value;
+        var   Formula: string := TXml.Unescape(Match.Groups[4].Value);
         const SiIndex  = Match.Groups[5].Value;
         const Value    = Match.Groups[6].Value;
 

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -1,4 +1,4 @@
-﻿unit Office4D.Excel.Writer;
+unit Office4D.Excel.Writer;
 
 interface
 
@@ -223,7 +223,7 @@ begin
         StateAttr := ' state="hidden"'
       else if FContent.Sheets[I].Visibility = TExcelSheetVisibility.VeryHidden then
         StateAttr := ' state="veryHidden"';
-      SB.Append('<sheet name="' + TXml.Escape(FContent.Sheets[I].Name) + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>')
+      SB.Append('<sheet name="' + TXml.Escape(FContent.Sheets[I].Name) + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>');
     end;
     SB.Append('</sheets>');
     SB.Append('</workbook>');
@@ -387,7 +387,7 @@ begin
             if Cell.GetHasFormula then
             begin
               const FloatVal = FormatFloat('0.##############', Cell.GetAsFloat, TFormatSettings.Invariant);
-              SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + '><f>' + Cell.GetFormula + '</f><v>' + FloatVal + '</v></c>');
+              SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + '><f>' + TXml.Escape(Cell.GetFormula) + '</f><v>' + FloatVal + '</v></c>');
             end
             else
             case Cell.CellType of

--- a/Tests/Source/Office4D.Tests.Excel.pas
+++ b/Tests/Source/Office4D.Tests.Excel.pas
@@ -198,6 +198,9 @@ type
 
     [Test]
     procedure SetFormula_RoundTrip_PreservesFormula;
+
+    [Test]
+    procedure SetFormula_RoundTrip_PreservesSpecialCharacters;
   end;
 
   [TestFixture]
@@ -597,6 +600,24 @@ begin
   Assert.IsTrue(Workbook2.Sheets[0].Cell['C1'].HasFormula);
   Assert.AreEqual('A1*B1', Workbook2.Sheets[0].Cell['C1'].Formula);
   Assert.AreEqual(Double(75), Workbook2.Sheets[0].Cell['C1'].AsFloat);
+end;
+
+procedure TExcelFormulaTests.SetFormula_RoundTrip_PreservesSpecialCharacters;
+begin
+  // Comparison operators and string concatenation are everyday formula syntax, so the
+  // formula text must be XML-escaped when written into <f> and unescaped when read back,
+  // the same as any other user-supplied text in this library.
+  const Formula = 'IF(A1<B1,"a&b",A1&">")';
+  var Sheet := FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 5;
+  Sheet.Cell['B1'].AsFloat := 15;
+  Sheet.Cell['C1'].SetFormula(Formula, 0);
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Workbook2 := TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+
+  Assert.AreEqual(Formula, Workbook2.Sheets[0].Cell['C1'].Formula, 'Formula special characters should round-trip');
 end;
 
 { TExcelLayoutTests }


### PR DESCRIPTION
Follow-up on #40. Cell formulas were written straight into `<f>` and read back without unescaping, so an everyday formula such as `IF(A1<B1,"a&b",...)` produced a corrupt workbook. Escape on write, unescape on read, both for regular formulas and for the shared-formula master text.

Also drops the accidental UTF-8 BOM and restores the missing statement semicolon that came in with #40.

Verified on Win32 Debug (RAD Studio 37.0): 332 tests pass. Without the source fix the new round-trip test fails with `Expected [IF(A1<B1,"a&b",A1&">")] but got []`.