### PR TITLE
fix: assigning a value to a cell clears its formula

### DIFF
--- a/Source/Excel/Office4D.Excel.Model.pas
+++ b/Source/Excel/Office4D.Excel.Model.pas
@@ -451,6 +451,7 @@ procedure TExcelCell.SetAsString(const Value: string);
 begin
   FStringValue := Value;
   FCellType := TCellType.StringValue;
+  FFormula := '';
 end;
 
 function TExcelCell.GetAsFloat: Double;
@@ -463,6 +464,7 @@ begin
   FFloatValue := Value;
   FStringValue := '';
   FCellType := TCellType.Number;
+  FFormula := '';
 end;
 
 function TExcelCell.GetAsBoolean: Boolean;
@@ -474,6 +476,7 @@ procedure TExcelCell.SetAsBoolean(const Value: Boolean);
 begin
   FBooleanValue := Value;
   FCellType := TCellType.Boolean;
+  FFormula := '';
 end;
 
 function TExcelCell.GetAsDateTime: TDateTime;
@@ -491,6 +494,7 @@ begin
   FDateTimeValue := Value;
   FFloatValue := Value;
   FCellType := TCellType.DateTime;
+  FFormula := '';
 end;
 
 function TExcelCell.GetIsString: Boolean;
@@ -909,10 +913,12 @@ end;
 
 procedure TExcelSheet.SetCellFormula(const Address, Formula, Value: string);
 begin
+  // Assign the cached value first: setting a value clears the formula, so the
+  // formula has to be applied afterwards to survive.
   var Cell := GetCell(Address) as TExcelCell;
-  Cell.FFormula := Formula;
   Cell.SetAsFloat(StrToFloatDef(Value, 0, TFormatSettings.Invariant));
   Cell.FStringValue := Value;
+  Cell.FFormula := Formula;
 end;
 
 procedure TExcelSheet.ClearColumn(const Column: string);

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -226,6 +226,10 @@ begin
       SB.Append('<sheet name="' + TXml.Escape(FContent.Sheets[I].Name) + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>');
     end;
     SB.Append('</sheets>');
+    // Formulas are not evaluated here, so every cached <v> is whatever was read
+    // or last assigned. Ask Excel to recalculate the whole workbook on load so
+    // the displayed results match the cell values this writer produced.
+    SB.Append('<calcPr calcId="0" fullCalcOnLoad="1"/>');
     SB.Append('</workbook>');
     Result := SB.ToString;
   finally

--- a/Tests/Source/Office4D.Tests.Excel.pas
+++ b/Tests/Source/Office4D.Tests.Excel.pas
@@ -201,6 +201,15 @@ type
 
     [Test]
     procedure SetFormula_RoundTrip_PreservesSpecialCharacters;
+
+    [Test]
+    procedure AssignValue_OverFormulaCell_ClearsFormula;
+
+    [Test]
+    procedure AssignValue_OverFormulaCell_RoundTripKeepsValue;
+
+    [Test]
+    procedure AssignString_OverFormulaCell_ClearsFormula;
   end;
 
   [TestFixture]
@@ -618,6 +627,48 @@ begin
   Workbook2.LoadFromFile(FTempFile);
 
   Assert.AreEqual(Formula, Workbook2.Sheets[0].Cell['C1'].Formula, 'Formula special characters should round-trip');
+end;
+
+procedure TExcelFormulaTests.AssignValue_OverFormulaCell_ClearsFormula;
+begin
+  // Assigning a literal replaces a formula, exactly as typing into the cell does in Excel.
+  // Leaving the formula in place would turn the assigned value into a mere cached result
+  // that Excel discards on the next recalculation.
+  var Sheet := FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 10;
+  Sheet.Cell['C1'].SetFormula('A1*2', 20);
+
+  Sheet.Cell['C1'].AsFloat := 99;
+
+  Assert.IsFalse(Sheet.Cell['C1'].HasFormula, 'Formula should be gone');
+  Assert.AreEqual('', Sheet.Cell['C1'].Formula);
+  Assert.AreEqual(Double(99), Sheet.Cell['C1'].AsFloat);
+end;
+
+procedure TExcelFormulaTests.AssignValue_OverFormulaCell_RoundTripKeepsValue;
+begin
+  var Sheet := FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 10;
+  Sheet.Cell['C1'].SetFormula('A1*2', 20);
+  Sheet.Cell['C1'].AsFloat := 99;
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Workbook2 := TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+
+  Assert.IsFalse(Workbook2.Sheets[0].Cell['C1'].HasFormula, 'Formula should not be written');
+  Assert.AreEqual(Double(99), Workbook2.Sheets[0].Cell['C1'].AsFloat);
+end;
+
+procedure TExcelFormulaTests.AssignString_OverFormulaCell_ClearsFormula;
+begin
+  var Sheet := FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['C1'].SetFormula('A1*2', 20);
+
+  Sheet.Cell['C1'].AsString := 'Label';
+
+  Assert.IsFalse(Sheet.Cell['C1'].HasFormula, 'Formula should be gone');
+  Assert.AreEqual('Label', Sheet.Cell['C1'].AsString);
 end;
 
 { TExcelLayoutTests }


### PR DESCRIPTION
### Problem

`TExcelWorkbookWriter` emits `<f>` in preference to the cell type, and none of the
`TExcelCell` setters clear `FFormula`. Assigning a value over a formula cell
therefore survives only as that formula's *cached result*, which Excel throws away
on the next recalculation:

```pascal
Sheet.Cell['C1'].SetFormula('A1*2', 20);
Sheet.Cell['C1'].AsFloat := 99;
// written as <c r="C1"><f>A1*2</f><v>99</v></c>
// Excel recalculates and shows 20
```

That breaks a natural use case: loading a prepared workbook whose output cells are
preloaded with placeholder formulas, and overwriting them with computed values.

### Changes

- `SetAsString`, `SetAsFloat`, `SetAsBoolean` and `SetAsDateTime` clear `FFormula`,
  matching what typing a literal into the cell does in Excel.
- `TExcelSheet.SetCellFormula` (the reader's path) assigns the cached value first and
  the formula afterwards, so a loaded formula still round-trips.
- The writer emits `<calcPr calcId="0" fullCalcOnLoad="1"/>`. The library evaluates no
  formulas, so the cached `<v>` of every formula the caller did *not* touch is stale the
  moment anything it depends on is written. Only a full recalculation on load makes the
  rendered sheet agree with the values written.

### Tests

Three regression tests in `TExcelFormulaTests`: value over formula, its save/load round
trip, and string over formula. Full suite passes (335 tests, Win64/dcc64).
