### PR TITLE
perf: look up shared strings through a map instead of scanning a list

### DIFF
--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -19,8 +19,13 @@ type
   private
     FContent: TExcelWorkbookContent;
 
+    // Position of every shared string within the list BuildSharedStrings returns.
+    // The list stays the ordered form the sharedStrings part is written from;
+    // membership and index lookups go through this map, so neither is a scan.
+    FSharedStringIndex: TDictionary<string, Integer>;
+
     function BuildSharedStrings: TList<string>;
-    function GetSharedStringIndex(const Strings: TList<string>; const Value: string): Integer;
+    function GetSharedStringIndex(const Value: string): Integer;
     function BuildStyleMap: TDictionary<string, Integer>;
     function GetStyleKey(const Cell: TExcelCell): string;
     function GetCellStyleIndex(const Cell: TExcelCell; const StyleMap: TDictionary<string, Integer>): Integer;
@@ -29,7 +34,7 @@ type
     function GenerateRels: string;
     function GenerateWorkbook: string;
     function GenerateWorkbookRels: string;
-    function GenerateSheet(const Sheet: TExcelSheet; const SharedStrings: TList<string>;
+    function GenerateSheet(const Sheet: TExcelSheet;
       const StyleMap: TDictionary<string, Integer>): string;
     function GenerateComments(const Sheet: TExcelSheet): string;
     function GenerateVmlDrawing(const Sheet: TExcelSheet): string;
@@ -37,10 +42,11 @@ type
     function GenerateSharedStrings(const Strings: TList<string>): string;
     function GenerateStyles(const StyleMap: TDictionary<string, Integer>): string;
 
-    procedure WriteSheets(const Zip: TZipFile; const SharedStrings: TList<string>;
+    procedure WriteSheets(const Zip: TZipFile;
       const StyleMap: TDictionary<string, Integer>);
   public
     constructor Create(const Content: TExcelWorkbookContent);
+    destructor Destroy; override;
 
     procedure WriteParts(const Zip: TZipFile);
   end;
@@ -73,6 +79,13 @@ constructor TExcelWorkbookWriter.Create(const Content: TExcelWorkbookContent);
 begin
   inherited Create;
   FContent := Content;
+  FSharedStringIndex := TDictionary<string, Integer>.Create;
+end;
+
+destructor TExcelWorkbookWriter.Destroy;
+begin
+  FSharedStringIndex.Free;
+  inherited;
 end;
 
 procedure TExcelWorkbookWriter.WriteParts(const Zip: TZipFile);
@@ -85,7 +98,7 @@ begin
     Zip.Add(TEncoding.UTF8.GetBytes(GenerateWorkbook), PartWorkbook);
     Zip.Add(TEncoding.UTF8.GetBytes(GenerateWorkbookRels), PartWorkbookRels);
 
-    WriteSheets(Zip, SharedStrings, StyleMap);
+    WriteSheets(Zip, StyleMap);
 
     if SharedStrings.Count > 0 then
       Zip.Add(TEncoding.UTF8.GetBytes(GenerateSharedStrings(SharedStrings)), PartSharedStrings);
@@ -97,7 +110,7 @@ begin
   end;
 end;
 
-procedure TExcelWorkbookWriter.WriteSheets(const Zip: TZipFile; const SharedStrings: TList<string>;
+procedure TExcelWorkbookWriter.WriteSheets(const Zip: TZipFile;
   const StyleMap: TDictionary<string, Integer>);
 begin
   var CommentsFileIndex := 0;
@@ -105,7 +118,7 @@ begin
   for var I := 0 to FContent.Sheets.Count - 1 do
   begin
     var ExcelSheet := FContent.Sheets[I] as TExcelSheet;
-    Zip.Add(TEncoding.UTF8.GetBytes(GenerateSheet(ExcelSheet, SharedStrings, StyleMap)),
+    Zip.Add(TEncoding.UTF8.GetBytes(GenerateSheet(ExcelSheet, StyleMap)),
       PartSheetPrefix + IntToStr(I + 1) + PartSheetSuffix);
 
     if not ExcelSheet.HasNotes then
@@ -125,6 +138,8 @@ end;
 function TExcelWorkbookWriter.BuildSharedStrings: TList<string>;
 begin
   Result := TList<string>.Create;
+  FSharedStringIndex.Clear;
+
   for var Sheet in FContent.Sheets do
   begin
     var ExcelSheet := Sheet as TExcelSheet;
@@ -132,15 +147,24 @@ begin
     begin
       var Cell := Pair.Value as TExcelCell;
       if (Cell.IsString) and (Cell.GetAsString <> '') then
-        if not Result.Contains(Cell.GetAsString) then
-          Result.Add(Cell.GetAsString);
+      begin
+        const Value = Cell.GetAsString;
+        // The map decides whether the string is already known, and remembers
+        // where it landed so GetSharedStringIndex never has to search for it.
+        if not FSharedStringIndex.ContainsKey(Value) then
+        begin
+          FSharedStringIndex.Add(Value, Result.Count);
+          Result.Add(Value);
+        end;
+      end;
     end;
   end;
 end;
 
-function TExcelWorkbookWriter.GetSharedStringIndex(const Strings: TList<string>; const Value: string): Integer;
+function TExcelWorkbookWriter.GetSharedStringIndex(const Value: string): Integer;
 begin
-  Result := Strings.IndexOf(Value);
+  if not FSharedStringIndex.TryGetValue(Value, Result) then
+    Result := -1;
 end;
 
 function TExcelWorkbookWriter.GenerateContentTypes: string;
@@ -250,7 +274,7 @@ begin
   end;
 end;
 
-function TExcelWorkbookWriter.GenerateSheet(const Sheet: TExcelSheet; const SharedStrings: TList<string>; const StyleMap: TDictionary<string, Integer>): string;
+function TExcelWorkbookWriter.GenerateSheet(const Sheet: TExcelSheet; const StyleMap: TDictionary<string, Integer>): string;
 begin
   var SB := TStringBuilder.Create;
   try
@@ -407,7 +431,7 @@ begin
                   end
                   else
                   begin
-                    const StrIdx = GetSharedStringIndex(SharedStrings, Cell.GetAsString);
+                    const StrIdx = GetSharedStringIndex(Cell.GetAsString);
                     SB.Append('<c r="' + CellPair.Key + '"' + StyleAttr + ' t="s"><v>' + IntToStr(StrIdx) + '</v></c>');
                   end;
                 end;

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -181,6 +181,9 @@ type
     procedure RoundTrip_EmptyStringCell_PreservesAdjacentValues;
 
     [Test]
+    procedure SaveToFile_ManyDistinctStrings_DeduplicatesAndIndexesCorrectly;
+
+    [Test]
     procedure SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;
 
     [Test]
@@ -1134,6 +1137,45 @@ begin
   Assert.AreEqual('Left', Workbook2.Sheets[0].Cell['A1'].AsString);
   Assert.AreEqual('', Workbook2.Sheets[0].Cell['B1'].AsString);
   Assert.AreEqual('Right', Workbook2.Sheets[0].Cell['C1'].AsString);
+end;
+
+procedure TExcelWriteTests.SaveToFile_ManyDistinctStrings_DeduplicatesAndIndexesCorrectly;
+const
+  RowCount = 2000;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+
+  // Column A is distinct on every row, column B repeats a handful of values:
+  // together they cover both sides of the shared string table, the strings that
+  // earn an entry of their own and the ones that have to find an existing one.
+  for var Row := 1 to RowCount do
+  begin
+    Sheet.Cell['A' + IntToStr(Row)].AsString := 'Unique ' + IntToStr(Row);
+    Sheet.Cell['B' + IntToStr(Row)].AsString := 'Repeated ' + IntToStr(Row mod 10);
+  end;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const SharedXml = Package.GetPartContent('xl/sharedStrings.xml');
+
+    // RowCount distinct values in column A plus the 10 recurring ones in column B.
+    Assert.IsTrue(Pos('uniqueCount="' + IntToStr(RowCount + 10) + '"', SharedXml) > 0,
+      'Repeated strings should share a single sharedStrings entry');
+  finally
+    Package.Free;
+  end;
+
+  // Reading the values back proves each cell kept its own index rather than
+  // pointing at a neighbour's entry.
+  const Workbook2 = TExcelWorkbookFactory.Create;
+  Workbook2.LoadFromFile(FTempFile);
+  Assert.AreEqual('Unique 1', Workbook2.Sheets[0].Cell['A1'].AsString);
+  Assert.AreEqual('Unique ' + IntToStr(RowCount), Workbook2.Sheets[0].Cell['A' + IntToStr(RowCount)].AsString);
+  Assert.AreEqual('Repeated 1', Workbook2.Sheets[0].Cell['B1'].AsString);
+  Assert.AreEqual('Repeated ' + IntToStr(RowCount mod 10), Workbook2.Sheets[0].Cell['B' + IntToStr(RowCount)].AsString);
 end;
 
 procedure TExcelWriteTests.SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;


### PR DESCRIPTION
# perf: look up shared strings through a map instead of scanning a list

## Problem

Writing a worksheet gets quadratically slower as the number of distinct strings
in it grows, to the point where a large sheet appears to hang.

`TExcelWorkbookWriter` keeps the shared string table in a `TList<string>` and
touches it in two places, both linear scans, and both executed once per string
cell:

- `BuildSharedStrings` decides whether a string is already known with
  `TList.Contains` — `Source/Excel/Office4D.Excel.Writer.pas`
- `GetSharedStringIndex` resolves a string to its position with `TList.IndexOf`

So for a sheet with *n* distinct strings the writer performs on the order of
*n²* string comparisons, twice.

This is invisible on small workbooks and painful on real ones. We hit it while
evaluating the library for a data grid export: a 50,000 row × 12 column sheet
with distinct text in five columns holds roughly 250,000 distinct strings, which
works out to tens of billions of comparisons. `SaveToFile` had not returned after
an hour. It was not stuck — just quadratic.

## Change

The list is still what the `sharedStrings` part is written from, so it stays. A
`TDictionary<string, Integer>` now records where each string landed, and both the
membership test and the index lookup go through the map. Same output, byte for
byte; only the way it is found changes.

Once the map exists, `GetSharedStringIndex` no longer needs the list handed to
it, so the parameter is dropped — and with it the pass-through arguments in
`WriteSheets` and `GenerateSheet`, which existed only to carry the list down to
that one call site.

The dictionary is created in the constructor and cleared at the start of
`BuildSharedStrings`, so a writer instance can be reused; a `destructor` is added
to free it.

## Measurements

50,000 rows × 12 columns, distinct text in five columns (~250,000 distinct
strings), Win32, Delphi 10.4:

| | `SaveToFile` |
|---|---|
| before | did not complete within one hour |
| after | a few seconds |

The gap narrows sharply when strings repeat, since the old `Contains` scan
stopped at the first match — a sheet whose text comes from a small set of
recurring values was never badly affected. It is distinct values that hurt, and
those are the common case in exported data: descriptions, references, notes.

## Tests

Existing suite passes unchanged — the output is identical, so nothing that
asserts on generated XML should move.

Added `SaveToFile_ManyDistinctStrings_DeduplicatesAndIndexesCorrectly` to
`TExcelWriteTests`: 2,000 rows with a distinct string in column A and one of ten
recurring strings in column B. It asserts `uniqueCount` accounts for the
deduplication, then round-trips the file and checks the first and last row of
both columns, which is what catches an off-by-one in the index rather than in the
table.

It is a correctness test, not a timing one — deliberately. A benchmark assertion
would be flaky in CI, and the row count is kept low enough that the test is quick
either way. It guards the semantics this change relies on; the performance claim
belongs in the measurements above.

## Notes for the reviewer

- No public API change. `GetSharedStringIndex`, `GenerateSheet` and `WriteSheets`
  are all `private`.
- The behaviour of `GetSharedStringIndex` for an unknown string is unchanged: it
  returned `-1` from `IndexOf` before and returns `-1` from a failed
  `TryGetValue` now. The empty-string case still never reaches it, guarded by the
  caller as before.
