### PR TITLE
fix: emit calcPr only when the workbook contains formulas

### DIFF
--- a/Source/Excel/Office4D.Excel.Model.pas
+++ b/Source/Excel/Office4D.Excel.Model.pas
@@ -848,8 +848,10 @@ end;
 function TExcelSheet.HasFormulas: Boolean;
 begin
   for var Pair in FCells do
+  begin
     if (Pair.Value as TExcelCell).GetHasFormula then
       Exit(True);
+  end;
   Result := False;
 end;
 

--- a/Source/Excel/Office4D.Excel.Model.pas
+++ b/Source/Excel/Office4D.Excel.Model.pas
@@ -136,6 +136,8 @@ type
     procedure SetNote(const Address: string; const Value: string);
     function HasNotes: Boolean;
 
+    function HasFormulas: Boolean;
+
     procedure ClearColumn(const Column: string);
     procedure ClearRow(const Row: Integer);
     procedure DeleteColumn(const Column: string);
@@ -841,6 +843,14 @@ end;
 function TExcelSheet.HasNotes: Boolean;
 begin
   Result := FNotes.Count > 0;
+end;
+
+function TExcelSheet.HasFormulas: Boolean;
+begin
+  for var Pair in FCells do
+    if (Pair.Value as TExcelCell).GetHasFormula then
+      Exit(True);
+  Result := False;
 end;
 
 class function TExcelSheet.ColumnLetterToNumber(const Column: string): Integer;

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -237,11 +237,13 @@ begin
 
   var HasFormulas := False;
   for var Sheet in FContent.Sheets do
+  begin
     if (Sheet as TExcelSheet).HasFormulas then
     begin
       HasFormulas := True;
       Break;
     end;
+  end;
 
   var SB := TStringBuilder.Create;
   try

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -235,6 +235,14 @@ begin
   if (FContent.Sheets.Count > 0) and not HasVisibleSheet then
     raise EExcelWorkbookException.Create('A workbook must contain at least one visible sheet');
 
+  var HasFormulas := False;
+  for var Sheet in FContent.Sheets do
+    if (Sheet as TExcelSheet).HasFormulas then
+    begin
+      HasFormulas := True;
+      Break;
+    end;
+
   var SB := TStringBuilder.Create;
   try
     SB.Append(XmlDeclaration);
@@ -250,10 +258,12 @@ begin
       SB.Append('<sheet name="' + TXml.Escape(FContent.Sheets[I].Name) + '" sheetId="' + IntToStr(I + 1) + '"' + StateAttr + ' r:id="rId' + IntToStr(I + 1) + '"/>');
     end;
     SB.Append('</sheets>');
-    // Formulas are not evaluated here, so every cached <v> is whatever was read
-    // or last assigned. Ask Excel to recalculate the whole workbook on load so
-    // the displayed results match the cell values this writer produced.
-    SB.Append('<calcPr calcId="0" fullCalcOnLoad="1"/>');
+    // Formulas are not evaluated here, so a formula cell's cached <v> is stale
+    // as soon as anything it depends on is written. Ask Excel to recalculate on
+    // load, but only when there is a formula to recalculate: a workbook without
+    // formulas keeps the exact output it had before.
+    if HasFormulas then
+      SB.Append('<calcPr calcId="0" fullCalcOnLoad="1"/>');
     SB.Append('</workbook>');
     Result := SB.ToString;
   finally

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -184,6 +184,12 @@ type
     procedure SaveToFile_ManyDistinctStrings_DeduplicatesAndIndexesCorrectly;
 
     [Test]
+    procedure SaveToFile_WithFormula_EmitsFullCalcOnLoad;
+
+    [Test]
+    procedure SaveToFile_WithoutFormulas_OmitsCalcPr;
+
+    [Test]
     procedure SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;
 
     [Test]
@@ -1176,6 +1182,48 @@ begin
   Assert.AreEqual('Unique ' + IntToStr(RowCount), Workbook2.Sheets[0].Cell['A' + IntToStr(RowCount)].AsString);
   Assert.AreEqual('Repeated 1', Workbook2.Sheets[0].Cell['B1'].AsString);
   Assert.AreEqual('Repeated ' + IntToStr(RowCount mod 10), Workbook2.Sheets[0].Cell['B' + IntToStr(RowCount)].AsString);
+end;
+
+procedure TExcelWriteTests.SaveToFile_WithFormula_EmitsFullCalcOnLoad;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 10;
+  Sheet.Cell['B1'].SetFormula('A1*2', 20);
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const WorkbookXml = Package.GetPartContent('xl/workbook.xml');
+    // The library never evaluates formulas, so a formula's cached value may be
+    // stale; only a full recalculation on load makes Excel show correct results.
+    Assert.IsTrue(Pos('<calcPr calcId="0" fullCalcOnLoad="1"/>', WorkbookXml) > 0,
+      'A workbook with formulas should ask Excel to recalculate on load');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.SaveToFile_WithoutFormulas_OmitsCalcPr;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 10;
+  Sheet.Cell['B1'].AsString := 'Label';
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const WorkbookXml = Package.GetPartContent('xl/workbook.xml');
+    // Nothing to recalculate, so the workbook keeps the output it always had:
+    // no forced recalculation, no "save changes?" prompt after merely viewing.
+    Assert.IsTrue(Pos('<calcPr', WorkbookXml) = 0,
+      'A workbook without formulas should not carry a calcPr element');
+  finally
+    Package.Free;
+  end;
 end;
 
 procedure TExcelWriteTests.SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;


### PR DESCRIPTION
## Problem

#44 made the writer emit `<calcPr calcId="0" fullCalcOnLoad="1"/>` in every workbook. For a workbook that holds at least one formula that is exactly right: the library never evaluates formulas, so a formula cell's cached `<v>` is stale as soon as anything it depends on is written, and only a full recalculation on load makes Excel show correct results.

For a workbook without any formula, however, the element buys nothing (there is nothing to recalculate) and it costs something: Excel performs the forced calculation pass on open, which can leave the user with a "save changes?" prompt after merely viewing an export. Formula-free exports are the most common use of this library, and their output now differs from every version before #44 for no benefit.

## Change

`GenerateWorkbook` scans the sheets for formula cells, the same way it already scans for a visible sheet, and emits `calcPr` only when a formula is present.

- `TExcelSheet.HasFormulas` is added next to `HasNotes`, following the same pattern; it early-exits on the first formula cell.
- No public API change: the helper lives on `TExcelSheet` and the writer already casts to it.

A workbook with formulas keeps the exact behaviour #44 introduced. A workbook without formulas is again byte-identical to what the writer produced before #44. A formula cell that is later overwritten with a value counts as no formula, which is consistent with #44 clearing the formula in that case.

## Tests

- `SaveToFile_WithFormula_EmitsFullCalcOnLoad`
- `SaveToFile_WithoutFormulas_OmitsCalcPr`

Full suite passes: 338 tests on Win32 and Win64, 0 warnings, 0 leaks.