### PR TITLE
docs: add commercial support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,3 +403,7 @@ MIT License - see [LICENSE](LICENSE) file
 2. Create a feature branch
 3. Write tests for new features
 4. Submit a pull request
+
+## Commercial Support
+
+This library is MIT licensed and free to use. For companies that depend on it commercially we offer support and maintenance agreements with guaranteed response times, and sponsored development of features you need. Contact us at [gdksoftware.com/contact-us](https://gdksoftware.com/contact-us) or open an issue to get in touch.


### PR DESCRIPTION
Adds a Commercial Support section to the README: the library stays MIT licensed and free, and companies that depend on it commercially can get a support or maintenance agreement, or sponsor development of features they need. Links to https://gdksoftware.com/contact-us.