### PR TITLE
Add RecalculateOnLoad to opt out of forced recalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ begin
   Sheet.Cell['B4'].Bold := True;
   Sheet.Cell['B4'].NumberFormat := '"$"#,##0.00';
 
+  // The library does not evaluate formulas. By default a workbook with formulas
+  // asks Excel to recalculate on load, so the calculated values above are never
+  // shown stale - but Excel then prompts to save on close, even if nothing was
+  // edited. Disable this to keep the cached values exactly as written:
+  Workbook.RecalculateOnLoad := False;
+
   // Boolean and DateTime
   Sheet.Cell['C2'].AsBoolean := True;
   Sheet.Cell['D2'].AsDateTime := Now;
@@ -361,7 +367,7 @@ Examples/      - Demo application
 - Cell styling: background color, border style, border color
 - Text formatting: bold, italic, underline, strikeout
 - Number formats (currency, percentage, custom)
-- Formulas with calculated values
+- Formulas with calculated values (optional recalculation on load via `RecalculateOnLoad`)
 - Column widths
 - Merged cells
 - Freeze panes

--- a/Source/Excel/Office4D.Excel.Model.pas
+++ b/Source/Excel/Office4D.Excel.Model.pas
@@ -173,6 +173,7 @@ type
   private
     FSheets: TList<IExcelSheet>;
     FMetadata: TDocumentMetadata;
+    FRecalculateOnLoad: Boolean;
   public
     constructor Create;
     destructor Destroy; override;
@@ -191,6 +192,7 @@ type
 
     property Sheets: TList<IExcelSheet> read FSheets;
     property Metadata: TDocumentMetadata read FMetadata write FMetadata;
+    property RecalculateOnLoad: Boolean read FRecalculateOnLoad write FRecalculateOnLoad;
   end;
 
 implementation
@@ -1139,6 +1141,7 @@ begin
   inherited Create;
   FSheets := TList<IExcelSheet>.Create;
   FMetadata.Clear;
+  FRecalculateOnLoad := True;
 end;
 
 destructor TExcelWorkbookContent.Destroy;

--- a/Source/Excel/Office4D.Excel.Workbook.pas
+++ b/Source/Excel/Office4D.Excel.Workbook.pas
@@ -35,6 +35,8 @@ type
     function GetSheet(Index: Integer): IExcelSheet;
     function GetSheetByName(const Name: string): IExcelSheet;
     function GetMetadata: TDocumentMetadata;
+    function GetRecalculateOnLoad: Boolean;
+    procedure SetRecalculateOnLoad(const Value: Boolean);
 
     function AddSheet(const Name: string): IExcelSheet;
     function SheetByName(const Name: string): IExcelSheet;
@@ -154,6 +156,16 @@ end;
 function TExcelWorkbook.GetMetadata: TDocumentMetadata;
 begin
   Result := FContent.Metadata;
+end;
+
+function TExcelWorkbook.GetRecalculateOnLoad: Boolean;
+begin
+  Result := FContent.RecalculateOnLoad;
+end;
+
+procedure TExcelWorkbook.SetRecalculateOnLoad(const Value: Boolean);
+begin
+  FContent.RecalculateOnLoad := Value;
 end;
 
 function TExcelWorkbook.AddSheet(const Name: string): IExcelSheet;

--- a/Source/Excel/Office4D.Excel.Writer.pas
+++ b/Source/Excel/Office4D.Excel.Writer.pas
@@ -263,8 +263,9 @@ begin
     // Formulas are not evaluated here, so a formula cell's cached <v> is stale
     // as soon as anything it depends on is written. Ask Excel to recalculate on
     // load, but only when there is a formula to recalculate: a workbook without
-    // formulas keeps the exact output it had before.
-    if HasFormulas then
+    // formulas carries no calcPr at all. The recalculation makes Excel prompt to
+    // save on close, so the caller can opt out via RecalculateOnLoad.
+    if HasFormulas and FContent.RecalculateOnLoad then
       SB.Append('<calcPr calcId="0" fullCalcOnLoad="1"/>');
     SB.Append('</workbook>');
     Result := SB.ToString;

--- a/Source/Excel/Office4D.Excel.pas
+++ b/Source/Excel/Office4D.Excel.pas
@@ -145,6 +145,8 @@ type
     function GetSheet(Index: Integer): IExcelSheet;
     function GetSheetByName(const Name: string): IExcelSheet;
     function GetMetadata: TDocumentMetadata;
+    function GetRecalculateOnLoad: Boolean;
+    procedure SetRecalculateOnLoad(const Value: Boolean);
 
     function AddSheet(const Name: string): IExcelSheet;
     procedure RemoveSheet(Index: Integer);
@@ -154,6 +156,11 @@ type
     property Sheets[Index: Integer]: IExcelSheet read GetSheet;
     function SheetByName(const Name: string): IExcelSheet;
     property Metadata: TDocumentMetadata read GetMetadata;
+    /// When True (the default), a workbook that contains formulas asks Excel to
+    /// recalculate on load so cached formula results never show stale values.
+    /// Excel then treats the file as modified and prompts to save on close, even
+    /// when nothing was edited. Set to False to keep the cached values as written.
+    property RecalculateOnLoad: Boolean read GetRecalculateOnLoad write SetRecalculateOnLoad;
   end;
 
   TExcelWorkbookFactory = class

--- a/Tests/Source/Office4D.Tests.Excel.Write.pas
+++ b/Tests/Source/Office4D.Tests.Excel.Write.pas
@@ -190,6 +190,12 @@ type
     procedure SaveToFile_WithoutFormulas_OmitsCalcPr;
 
     [Test]
+    procedure RecalculateOnLoad_NewWorkbook_IsTrue;
+
+    [Test]
+    procedure SaveToFile_RecalculateOnLoadDisabled_OmitsCalcPr;
+
+    [Test]
     procedure SaveToFile_DateCell_UsesLocaleAwareShortDateFormat;
 
     [Test]
@@ -1221,6 +1227,33 @@ begin
     // no forced recalculation, no "save changes?" prompt after merely viewing.
     Assert.IsTrue(Pos('<calcPr', WorkbookXml) = 0,
       'A workbook without formulas should not carry a calcPr element');
+  finally
+    Package.Free;
+  end;
+end;
+
+procedure TExcelWriteTests.RecalculateOnLoad_NewWorkbook_IsTrue;
+begin
+  Assert.IsTrue(FWorkbook.RecalculateOnLoad, 'Recalculation on load should be on by default');
+end;
+
+procedure TExcelWriteTests.SaveToFile_RecalculateOnLoadDisabled_OmitsCalcPr;
+begin
+  const Sheet = FWorkbook.AddSheet('Sheet1');
+  Sheet.Cell['A1'].AsFloat := 10;
+  Sheet.Cell['B1'].SetFormula('A1*2', 20);
+  FWorkbook.RecalculateOnLoad := False;
+
+  FWorkbook.SaveToFile(FTempFile);
+
+  var Package := TOXMLPackage.Create;
+  try
+    Package.Open(FTempFile);
+    const WorkbookXml = Package.GetPartContent('xl/workbook.xml');
+    // The caller opted out, so the cached formula values are kept as written and
+    // Excel does not prompt to save after merely viewing the file.
+    Assert.IsTrue(Pos('<calcPr', WorkbookXml) = 0,
+      'RecalculateOnLoad = False should suppress the calcPr element');
   finally
     Package.Free;
   end;


### PR DESCRIPTION
## Problem

Since #44/#46 a workbook that contains formulas is written with `<calcPr calcId="0" fullCalcOnLoad="1"/>`. That keeps cached formula results from showing stale values, but it also makes Excel treat the file as modified: anyone who opens a generated report and closes it without touching anything gets a "save changes?" prompt. There was no way to turn that off.

## Change

- `IExcelWorkbook.RecalculateOnLoad: Boolean`, default `True`, so existing behaviour is unchanged.
- The writer emits `calcPr` only when the workbook has formulas **and** `RecalculateOnLoad` is set.
- README documents the prompt next to the formula example, with the opt-out.

## Tests

- `RecalculateOnLoad_NewWorkbook_IsTrue`
- `SaveToFile_RecalculateOnLoadDisabled_OmitsCalcPr`

Full suite: 340 tests, 0 failures, 0 leaks (Release/Win64).